### PR TITLE
Fix GCS MCP server account perms to be able to create and list buckets

### DIFF
--- a/terraform/gcs_mcp_server_resources/terraform.tfvars
+++ b/terraform/gcs_mcp_server_resources/terraform.tfvars
@@ -20,7 +20,7 @@ mcp_server_service_account_name = "gcs-mcp-server"
 
 mcp_server_iam_project_roles = {
   "p-dev-gce-60pf" = [
-    "roles/storage.objectAdmin"
+    "roles/storage.admin"
   ]
 }
 


### PR DESCRIPTION
Fix GCS MCP server account perms to be able to create and list buckets