### PR TITLE
AI Agent / Implement dynamic auth based on the enviroment (local or production - agent engine)

### DIFF
--- a/agent/core_agent/agent.py
+++ b/agent/core_agent/agent.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import vertexai
 from vertexai import agent_engines
@@ -27,10 +26,7 @@ full_bq_mcp_server_path = mcp_servers.BIGQUERY_URL + mcp_servers.BIGQUERY_ENDPOI
 full_gcs_mcp_server_path = mcp_servers.GCS_URL + mcp_servers.GCS_ENDPOINT
 full_drive_mcp_server_path = mcp_servers.DRIVE_URL + mcp_servers.DRIVE_ENDPOINT
 
-is_deployed = (
-    os.environ.get("K_SERVICE") is not None
-    or os.environ.get("GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY") == "true"
-)
+is_deployed = gcp_config.IS_DEPLOYED
 
 vertexai.Client(
     project=project_id,

--- a/agent/core_agent/config.py
+++ b/agent/core_agent/config.py
@@ -30,6 +30,13 @@ class GCPConfig(BaseSettings):
             description="GCP Region where most of the services will be deployed",
         ),
     ]
+    IS_DEPLOYED: Annotated[
+        bool,
+        Field(
+            default=True,
+            description="Flag to determine if the agent is running in a deployed environment. Defaults to True, override in local .env to False.",
+        ),
+    ]
 
 
 class AgentConfig(BaseSettings):


### PR DESCRIPTION
This PR implements dynamic authentication for the Google Drive MCP Toolset depending on the deployment environment, resolving issues with local UI testing versus the cloudly deployed agent.
### Changes Made:
*   Added an `is_deployed` flag to automatically detect if the agent is running in Vertex AI Agent Engine (`K_SERVICE` or `GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY`).
*   **When Local:** Configured the Drive toolset with `OAuth2Flows` and `AuthCredential` to correctly trigger the adk-web UI authorization popup, while still injecting `X-Serverless-Authorization` headers to reach the MCP Server.
*   **When Deployed:** Bypasses local OAuth schemas and directly injects both the `X-Serverless-Authorization` header and the Gemini Enterprise delegated `Authorization` tokens.
## How to Test
1. Run `make run-ui-agent` locally.
2. Trigger an action requiring Google Drive access.
3. Verify that the agent generates the web UI popup to authorize the OAuth consent screen.