### PR TITLE
MCP Servers/Google Calendar /Server Creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ verify-all-ci:
 	$(MAKE) verify-bq-ci
 	$(MAKE) verify-gcs-ci
 	$(MAKE) verify-drive-ci
+	$(MAKE) verify-calendar-ci
 
 create-cloudbuild-triggers:
 	./terraform/scripts/cicd_triggers_creation.sh
@@ -113,10 +114,10 @@ run-gcs-tests:
 	uv run --group mcp_gcs pytest mcp_servers/gcs/tests/
 
 run-gcs-mcp-locally:
-	uv run --group mcp_gcs python -m mcp_servers.gcs.app.main --host localhost --port 8080
+	uv run --group mcp_gcs python -m mcp_servers.gcs.app.main --host localhost --port 8082
 
 run-gcs-mcp-smoke:
-	uv run --group mcp_gcs python mcp_servers/gcs/scripts/mcp_smoke_test.py --endpoint http://localhost:8080/mcp --bucket $(BUCKET) --prefix $(PREFIX)$(if $(BUCKET_PREFIX), --bucket-prefix $(BUCKET_PREFIX),)
+	uv run --group mcp_gcs python mcp_servers/gcs/scripts/mcp_smoke_test.py --endpoint http://localhost:8082/mcp --bucket $(BUCKET) --prefix $(PREFIX)$(if $(BUCKET_PREFIX), --bucket-prefix $(BUCKET_PREFIX),)
 
 build-gcs-mcp-image:
 	docker build -t test-gcs-mcp-server -f mcp_servers/gcs/Dockerfile .
@@ -129,3 +130,22 @@ verify-gcs-ci:
 
 test-gcs-terraform:
 	cd terraform/gcs_mcp_server_resources && terraform fmt -check -recursive && terraform init -backend=false && terraform test
+
+### Google Calendar & Meet MCP Commands ###
+
+run-calendar-precommit:
+	uvx pre-commit run --files mcp_servers/google_calendar/**/*
+
+run-calendar-tests:
+	uv run --group mcp_calendar pytest mcp_servers/google_calendar/tests/
+
+run-calendar-mcp-locally:
+	uv run --group mcp_calendar python -m mcp_servers.google_calendar.app.main --host localhost --port 8083
+
+build-calendar-mcp-image:
+	docker build -t test-calendar-mcp-server -f mcp_servers/google_calendar/Dockerfile .
+
+verify-calendar-ci:
+	$(MAKE) run-calendar-precommit
+	$(MAKE) run-calendar-tests
+	$(MAKE) build-calendar-mcp-image

--- a/mcp_servers/google_calendar/Dockerfile
+++ b/mcp_servers/google_calendar/Dockerfile
@@ -1,0 +1,33 @@
+# Define a global ARG before the first FROM
+ARG UV_VERSION=0.10.7
+
+# Use the predefined image layer as an alias so we can copy from it later
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_image
+
+# Use a lightweight Python base image
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Install the required uv version using the alias
+COPY --from=uv_image /uv /uvx /bin/
+
+# Set the working directory to /app
+WORKDIR /app
+
+# NOTE: The Docker build context MUST be the root of the repository
+COPY pyproject.toml uv.lock ./
+
+# Install only the Calendar MCP server dependencies using uv
+RUN uv sync --group mcp_calendar --no-dev --no-install-project --locked
+
+# Copy the app directory to preserve module structure
+COPY mcp_servers/google_calendar/app/ mcp_servers/google_calendar/app/
+
+# Expose port 8080 (CloudRun default port)
+ENV PORT=8080
+EXPOSE ${PORT}
+
+# Run the server using uv run
+CMD ["sh", "-c", "uv run --group mcp_calendar --no-sync python -m mcp_servers.google_calendar.app.main --host 0.0.0.0 --port ${PORT}"]

--- a/mcp_servers/google_calendar/README.md
+++ b/mcp_servers/google_calendar/README.md
@@ -12,6 +12,15 @@ By combining these, an agent can perform complex queries like: *"Find the transc
 
 ---
 
+## Architectural Highlights
+
+- **Standardized Schema Contracts**: Built exclusively using Pydantic `BaseModel`. All exposed tools receive well-defined `Request` objects and return consistent `Response` objects.
+- **Traceability (Parameter Echoing)**: Response schemas dynamically inherit from their corresponding Requests and a common `BaseResponse`. This means every tool returns the `execution_status` ("success" or "error"), the `execution_message`, and crucially, echoes back the original input parameters. The Agent never loses context when attempting rollbacks or compensations. 
+- **Graceful Error Handling**: Instead of raising raw runtime exceptions on API HTTP errors, the Server catches exceptions and securely returns them wrapped within the `BaseResponse` standard format.
+- **Unified Observability**: Leveraging `loguru`, the server implements tiered logging natively down to private components: `DEBUG` for mapping and fetching, `INFO` for unified routing boundaries, and `ERROR` for API exceptions.
+
+---
+
 ## Components
 
 ### [Calendar Client](./app/calendar/README.md)
@@ -37,20 +46,36 @@ To use all features of this server, your OAuth token must include:
 
 ---
 
-## Quick Start
+## Quick Start & Make Commands
+
+The project manages continuous integration and local development through `uv` and the global repository `Makefile`.
 
 ### 1. Installation
-This project uses `uv` for dependency management.
 
+Sync the exact dependencies for the calendar server securely using your `uv.lock`:
 ```bash
-uv sync --group mcp_calendar
+uv sync --group mcp_calendar --all-groups --locked
 ```
 
-### 2. Running Tests
-We maintain a robust test suite covering RFC3339 validation and API error handling.
+### 2. Running Locally
 
+We have registered a port footprint across our system to avoid collisions. The Calendar MCP runs locally on port `8083`:
 ```bash
-uv run pytest mcp_servers/google_calendar/tests/
+make run-calendar-mcp-locally
+```
+
+### 3. Running Tests & QA
+
+We maintain a robust test suite covering RFC3339 validation, base response schema inheritance, parameter echoing edge cases, and API failure modes.
+
+Run your tests using Make:
+```bash
+make run-calendar-tests
+```
+
+Or verify the entire pipeline (Pre-commit, Pytest, and Docker Build):
+```bash
+make verify-calendar-ci
 ```
 
 ---

--- a/mcp_servers/google_calendar/app/calendar/calendar_client.py
+++ b/mcp_servers/google_calendar/app/calendar/calendar_client.py
@@ -47,6 +47,7 @@ class CalendarClient:
         Return:
             list[Attendee]: A list of Attendee objects.
         """
+        logger.debug("Parsing attendees...")
         attendees = []
         for attendee in raw_attendees:
             attendees.append(
@@ -90,6 +91,7 @@ class CalendarClient:
         Return:
             Optional[MeetSessionData]: A MeetSessionData object or None if no Meet link is found.
         """
+        logger.debug("Parsing meet session data...")
         meeting_code = meet_data_dict.get("conferenceId")
         if not meeting_code:
             return None
@@ -117,6 +119,7 @@ class CalendarClient:
         Return:
             list[EventAttachment]: A list of EventAttachment objects.
         """
+        logger.debug("Parsing attachments...")
         attachments = []
         for attachment in raw_attachments:
             attachments.append(

--- a/mcp_servers/google_calendar/app/calendar/calendar_client.py
+++ b/mcp_servers/google_calendar/app/calendar/calendar_client.py
@@ -25,7 +25,6 @@ class CalendarClient:
         Return:
             None
         """
-        self.creds = creds
         self.calendar = build(
             CALENDAR_CONFIG.calendar_api_service_name,
             CALENDAR_CONFIG.calendar_api_version,

--- a/mcp_servers/google_calendar/app/config.py
+++ b/mcp_servers/google_calendar/app/config.py
@@ -32,7 +32,10 @@ class CalendarAPIConfig(CalendarMcpConfigBase):
         tuple[Scopes, ...],
         Field(
             default=(Scopes.CALENDAR_READONLY, Scopes.MEET_READONLY),
-            description="Full set of scopes required for the Calendar MCP server.",
+            description=(
+                "Full set of scopes required for the Calendar MCP server. "
+                "Defined as a tuple to ensure global config immutability."
+            ),
         ),
     ]
     google_token_info_url: Annotated[

--- a/mcp_servers/google_calendar/app/config.py
+++ b/mcp_servers/google_calendar/app/config.py
@@ -1,0 +1,113 @@
+from typing import Annotated
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+from enum import StrEnum
+
+
+class Scopes(StrEnum):
+    """Enumeration of required Google Calendar and Meet API scopes."""
+
+    CALENDAR_READONLY = "https://www.googleapis.com/auth/calendar.events.readonly"
+    MEET_READONLY = "https://www.googleapis.com/auth/meetings.space.readonly"
+
+
+class CalendarMcpConfigBase(BaseSettings):
+    """Shared immutable configuration base for the Calendar MCP server.
+    Ensures consistent Pydantic settings across all configuration models.
+    """
+
+    model_config = SettingsConfigDict(
+        extra="forbid",
+        frozen=True,
+        env_file_encoding="utf-8",
+    )
+
+
+class CalendarAPIConfig(CalendarMcpConfigBase):
+    """Configuration for Google Calendar/Meet API scopes and authentication endpoints.
+    Defines the default set of scopes needed for operation and OAuth endpoints.
+    """
+
+    required_scopes: Annotated[
+        tuple[Scopes, ...],
+        Field(
+            default=(Scopes.CALENDAR_READONLY, Scopes.MEET_READONLY),
+            description="Full set of scopes required for the Calendar MCP server.",
+        ),
+    ]
+    google_token_info_url: Annotated[
+        str,
+        Field(
+            default="https://oauth2.googleapis.com/tokeninfo",
+            description="Google OAuth2 token info endpoint.",
+        ),
+    ]
+    google_accounts_issuer_url: Annotated[
+        str,
+        Field(
+            default="https://accounts.google.com",
+            description="Google Accounts issuer URL.",
+        ),
+    ]
+
+
+class CalendarServerConfig(BaseSettings):
+    """Configuration for the MCP server's network and operational settings.
+    Binds the server to the specific host, port, and behavior (stateless, JSON).
+    """
+
+    server_name: Annotated[
+        str,
+        Field(
+            default="google-calendar-mcp-server",
+            description="Published name of the Calendar MCP server.",
+        ),
+    ]
+    default_host: Annotated[
+        str,
+        Field(
+            default="0.0.0.0",
+            description="Default interface the Calendar MCP server binds to.",
+        ),
+    ]
+    default_port: Annotated[
+        int,
+        Field(
+            default=8080,
+            ge=1,
+            le=65535,
+            description="Default port for the Calendar MCP server (from registry).",
+        ),
+    ]
+    default_log_level: Annotated[
+        str,
+        Field(
+            default="INFO",
+            description="Default log level for the local Calendar MCP server.",
+        ),
+    ]
+    stateless_http: Annotated[
+        bool,
+        Field(
+            default=True,
+            description="Whether the server should use stateless HTTP mode.",
+        ),
+    ]
+    json_response: Annotated[
+        bool,
+        Field(
+            default=True,
+            description="Whether the MCP server should use JSON responses.",
+        ),
+    ]
+    debug: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Whether the Starlette app should run in debug mode.",
+        ),
+    ]
+
+
+CALENDAR_API_CONFIG = CalendarAPIConfig()
+CALENDAR_SERVER_CONFIG = CalendarServerConfig()

--- a/mcp_servers/google_calendar/app/connector.py
+++ b/mcp_servers/google_calendar/app/connector.py
@@ -41,13 +41,13 @@ class EventsClient:
 
         Args:
             max_events (int): The maximum number of events to return.
-            date_min (str | None): Optional lower bound date filter (YYYY-MM-DD).
-            time_min (str | None): Optional lower bound time filter (HH:MM:SSZ).
-            date_max (str | None): Optional upper bound date filter (YYYY-MM-DD).
-            time_max (str | None): Optional upper bound time filter (HH:MM:SSZ).
-            query (str | None): Optional search terms.
+            date_min (Optional[str]): Lower bound date filter (YYYY-MM-DD).
+            time_min (Optional[str]): Lower bound time filter (HH:MM:SSZ).
+            date_max (Optional[str]): Upper bound date filter (YYYY-MM-DD).
+            time_max (Optional[str]): Upper bound time filter (HH:MM:SSZ).
+            query (Optional[str]): Optional search terms.
 
-        Return:
+        Returns:
             list[CalendarEvent]: A list of parsed CalendarEvent objects.
         """
         return self._calendar.list_events(

--- a/mcp_servers/google_calendar/app/connector.py
+++ b/mcp_servers/google_calendar/app/connector.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from loguru import logger
 from google.oauth2.credentials import Credentials
 
 from .calendar import CalendarClient
@@ -23,6 +24,7 @@ class EventsClient:
         Args:
             creds (Credentials): Valid Google OAuth2 credentials.
         """
+        logger.info("Initializing unified EventsClient")
         self._calendar = CalendarClient(creds)
         self._meet = MeetClient(creds)
 
@@ -50,6 +52,7 @@ class EventsClient:
         Returns:
             list[CalendarEvent]: A list of parsed CalendarEvent objects.
         """
+        logger.info("EventsClient routing: list_events")
         return self._calendar.list_events(
             max_events=max_events,
             date_min=date_min,
@@ -70,6 +73,9 @@ class EventsClient:
         Returns:
             list[MeetSession]: A list of objects summarizing each meeting session.
         """
+        logger.info(
+            f"EventsClient routing: list_meet_sessions for code '{meeting_code}'"
+        )
         return self._meet.list_meet_sessions(meeting_code=meeting_code)
 
     def list_meet_participants(self, meet_session_id: str) -> list[MeetParticipant]:
@@ -81,6 +87,9 @@ class EventsClient:
         Returns:
             list[MeetParticipant]: A list of participants with join/leave metadata.
         """
+        logger.info(
+            f"EventsClient routing: list_meet_participants for session '{meet_session_id}'"
+        )
         return self._meet.list_meet_participants(meet_session_id=meet_session_id)
 
     def get_meet_recording(self, recording_id: str) -> MeetRecording:
@@ -92,6 +101,7 @@ class EventsClient:
         Returns:
             MeetRecording: A model containing the recording metadata.
         """
+        logger.info(f"EventsClient routing: get_meet_recording for id '{recording_id}'")
         return self._meet.get_meet_recording(recording_id=recording_id)
 
     def get_meet_transcript(self, transcript_id: str) -> MeetTranscript:
@@ -103,4 +113,7 @@ class EventsClient:
         Returns:
             MeetTranscript: A model containing transcript metadata.
         """
+        logger.info(
+            f"EventsClient routing: get_meet_transcript for id '{transcript_id}'"
+        )
         return self._meet.get_meet_transcript(transcript_id=transcript_id)

--- a/mcp_servers/google_calendar/app/main.py
+++ b/mcp_servers/google_calendar/app/main.py
@@ -1,0 +1,37 @@
+import argparse
+import sys
+from loguru import logger
+from .mcp_server import mcp
+from .config import CALENDAR_SERVER_CONFIG
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Google Calendar MCP Server")
+    parser.add_argument(
+        "--host",
+        default=CALENDAR_SERVER_CONFIG.default_host,
+        help="Host interface to bind to",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=CALENDAR_SERVER_CONFIG.default_port,
+        help="Port to bind to",
+    )
+    parser.add_argument(
+        "--log-level",
+        type=str.upper,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default=CALENDAR_SERVER_CONFIG.default_log_level,
+        help="Logging level",
+    )
+    args = parser.parse_args()
+
+    # Configure logging
+    logger.remove()
+    logger.add(sys.stderr, level=args.log_level)
+
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+    mcp.settings.log_level = args.log_level
+
+    mcp.run(transport="streamable-http")

--- a/mcp_servers/google_calendar/app/mcp_server.py
+++ b/mcp_servers/google_calendar/app/mcp_server.py
@@ -1,0 +1,222 @@
+import asyncio
+import logging
+from mcp.server.auth.settings import AuthSettings
+from mcp.server.fastmcp import FastMCP
+from pydantic import AnyHttpUrl
+
+from .config import CALENDAR_API_CONFIG, CALENDAR_SERVER_CONFIG
+from .security import GoogleCalendarTokenVerifier, create_events_client
+from .schemas import (
+    GetMeetRecordingRequest,
+    GetMeetRecordingResponse,
+    GetMeetTranscriptRequest,
+    GetMeetTranscriptResponse,
+    ListCalendarEventsRequest,
+    ListCalendarEventsResponse,
+    ListMeetParticipantsRequest,
+    ListMeetParticipantsResponse,
+    ListMeetSessionsRequest,
+    ListMeetSessionsResponse,
+)
+
+
+logger = logging.getLogger(__name__)
+
+# Instantiate MCP Server
+mcp = FastMCP(
+    CALENDAR_SERVER_CONFIG.server_name,
+    stateless_http=CALENDAR_SERVER_CONFIG.stateless_http,
+    json_response=CALENDAR_SERVER_CONFIG.json_response,
+    host=CALENDAR_SERVER_CONFIG.default_host,
+    port=CALENDAR_SERVER_CONFIG.default_port,
+    debug=CALENDAR_SERVER_CONFIG.debug,
+    token_verifier=GoogleCalendarTokenVerifier(),
+    auth=AuthSettings(
+        issuer_url=AnyHttpUrl(CALENDAR_API_CONFIG.google_accounts_issuer_url),
+        resource_server_url=AnyHttpUrl(
+            f"http://{CALENDAR_SERVER_CONFIG.default_host}:{CALENDAR_SERVER_CONFIG.default_port}"
+        ),
+    ),
+)
+
+
+@mcp.tool()
+async def list_calendar_events(
+    request: ListCalendarEventsRequest,
+) -> ListCalendarEventsResponse:
+    """Fetch and parse calendar events into structured models.
+    Retrieves events based on optional filters for date, time, and query terms.
+
+    Args:
+        request (ListCalendarEventsRequest): The request parameters.
+
+    Returns:
+        ListCalendarEventsResponse: A response containing the list of calendar events and execution status.
+    """
+    logger.info(
+        "Tool call: list_calendar_events(max_events=%s, query=%s)",
+        request.max_events,
+        request.query,
+    )
+    try:
+        client = create_events_client()
+        events = await asyncio.to_thread(
+            client.list_events,
+            max_events=request.max_events,
+            date_min=request.date_min,
+            time_min=request.time_min,
+            date_max=request.date_max,
+            time_max=request.time_max,
+            query=request.query,
+        )
+        return ListCalendarEventsResponse(
+            execution_status="success",
+            events=events,
+        )
+    except Exception as exc:
+        logger.exception("Error listing calendar events")
+        return ListCalendarEventsResponse(
+            execution_status="error",
+            execution_message=f"Error listing calendar events: {str(exc)}",
+            events=[],
+        )
+
+
+@mcp.tool()
+async def list_meet_sessions(
+    request: ListMeetSessionsRequest,
+) -> ListMeetSessionsResponse:
+    """Lists and summarizes all Meet sessions for a specific meeting code.
+    Identifies historical records for the specified 10-letter meeting ID.
+
+    Args:
+        request (ListMeetSessionsRequest): The request parameters containing the meeting code.
+
+    Returns:
+        ListMeetSessionsResponse: A response containing the Meet sessions and execution status.
+    """
+    logger.info("Tool call: list_meet_sessions(meeting_code=%s)", request.meeting_code)
+    try:
+        client = create_events_client()
+        sessions = await asyncio.to_thread(
+            client.list_meet_sessions, meeting_code=request.meeting_code
+        )
+        return ListMeetSessionsResponse(
+            execution_status="success",
+            meeting_code=request.meeting_code,
+            sessions=sessions,
+        )
+    except Exception as exc:
+        logger.exception("Error listing meet sessions")
+        return ListMeetSessionsResponse(
+            execution_status="error",
+            execution_message=f"Error listing meet sessions: {str(exc)}",
+            meeting_code=request.meeting_code,
+            sessions=[],
+        )
+
+
+@mcp.tool()
+async def list_meet_participants(
+    request: ListMeetParticipantsRequest,
+) -> ListMeetParticipantsResponse:
+    """Retrieves detailed participant data for a specific Meet session.
+    Lists join/leave times and identity metadata for everyone in the session.
+
+    Args:
+        request (ListMeetParticipantsRequest): The request parameters containing the session ID.
+
+    Returns:
+        ListMeetParticipantsResponse: A response containing the participants and execution status.
+    """
+    logger.info(
+        "Tool call: list_meet_participants(meet_session_id=%s)", request.meet_session_id
+    )
+    try:
+        client = create_events_client()
+        participants = await asyncio.to_thread(
+            client.list_meet_participants, meet_session_id=request.meet_session_id
+        )
+        return ListMeetParticipantsResponse(
+            execution_status="success",
+            meet_session_id=request.meet_session_id,
+            participants=participants,
+        )
+    except Exception as exc:
+        logger.exception("Error listing meet participants")
+        return ListMeetParticipantsResponse(
+            execution_status="error",
+            execution_message=f"Error listing meet participants: {str(exc)}",
+            meet_session_id=request.meet_session_id,
+            participants=[],
+        )
+
+
+@mcp.tool()
+async def get_meet_recording(
+    request: GetMeetRecordingRequest,
+) -> GetMeetRecordingResponse:
+    """Retrieves detailed metadata for a specific Google Meet recording.
+    Includes state, start/end times, and the associated Google Drive identifier.
+
+    Args:
+        request (GetMeetRecordingRequest): The request parameters containing the recording ID.
+
+    Returns:
+        GetMeetRecordingResponse: A response containing the recording metadata and execution status.
+    """
+    logger.info("Tool call: get_meet_recording(recording_id=%s)", request.recording_id)
+    try:
+        client = create_events_client()
+        recording = await asyncio.to_thread(
+            client.get_meet_recording, recording_id=request.recording_id
+        )
+        return GetMeetRecordingResponse(
+            execution_status="success",
+            recording_id=request.recording_id,
+            recording=recording,
+        )
+    except Exception as exc:
+        logger.exception("Error getting meet recording")
+        return GetMeetRecordingResponse(
+            execution_status="error",
+            execution_message=f"Error getting meet recording: {str(exc)}",
+            recording_id=request.recording_id,
+            recording=None,
+        )
+
+
+@mcp.tool()
+async def get_meet_transcript(
+    request: GetMeetTranscriptRequest,
+) -> GetMeetTranscriptResponse:
+    """Retrieves detailed metadata for a specific Google Meet transcript.
+    Includes state and the associated Google Docs document identifier.
+
+    Args:
+        request (GetMeetTranscriptRequest): The request parameters containing the transcript ID.
+
+    Returns:
+        GetMeetTranscriptResponse: A response containing the transcript metadata and execution status.
+    """
+    logger.info(
+        "Tool call: get_meet_transcript(transcript_id=%s)", request.transcript_id
+    )
+    try:
+        client = create_events_client()
+        transcript = await asyncio.to_thread(
+            client.get_meet_transcript, transcript_id=request.transcript_id
+        )
+        return GetMeetTranscriptResponse(
+            execution_status="success",
+            transcript_id=request.transcript_id,
+            transcript=transcript,
+        )
+    except Exception as exc:
+        logger.exception("Error getting meet transcript")
+        return GetMeetTranscriptResponse(
+            execution_status="error",
+            execution_message=f"Error getting meet transcript: {str(exc)}",
+            transcript_id=request.transcript_id,
+            transcript=None,
+        )

--- a/mcp_servers/google_calendar/app/mcp_server.py
+++ b/mcp_servers/google_calendar/app/mcp_server.py
@@ -1,5 +1,5 @@
 import asyncio
-import logging
+from loguru import logger
 from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import FastMCP
 from pydantic import AnyHttpUrl
@@ -19,8 +19,6 @@ from .schemas import (
     ListMeetSessionsResponse,
 )
 
-
-logger = logging.getLogger(__name__)
 
 # Instantiate MCP Server
 mcp = FastMCP(

--- a/mcp_servers/google_calendar/app/meet/meet_client.py
+++ b/mcp_servers/google_calendar/app/meet/meet_client.py
@@ -32,7 +32,6 @@ class MeetClient:
         Args:
             creds (Credentials): Authorized Google OAuth2 credentials object.
         """
-        self.creds = creds
         self.meet = build(
             MEET_CONFIG.meet_api_service_name,
             MEET_CONFIG.meet_api_version,

--- a/mcp_servers/google_calendar/app/meet/meet_client.py
+++ b/mcp_servers/google_calendar/app/meet/meet_client.py
@@ -236,6 +236,7 @@ class MeetClient:
             list[dict[str, Any]]: A list of raw recording dictionaries from the API.
         """
         try:
+            logger.debug(f"Fetching recordings for session: {meet_session_id}")
             response = (
                 self.meet.conferenceRecords()
                 .recordings()
@@ -243,7 +244,10 @@ class MeetClient:
                 .execute()
             )
             return response.get("recordings", [])
-        except HttpError:
+        except HttpError as exc:
+            logger.error(
+                f"Error fetching recordings for session {meet_session_id}: {exc}"
+            )
             return []
 
     def _fetch_transcripts(self, meet_session_id: str) -> list[dict]:
@@ -259,6 +263,7 @@ class MeetClient:
             list[dict[str, Any]]: A list of raw transcript dictionaries from the API.
         """
         try:
+            logger.debug(f"Fetching transcripts for session: {meet_session_id}")
             response = (
                 self.meet.conferenceRecords()
                 .transcripts()
@@ -266,7 +271,10 @@ class MeetClient:
                 .execute()
             )
             return response.get("transcripts", [])
-        except HttpError:
+        except HttpError as exc:
+            logger.error(
+                f"Error fetching transcripts for session {meet_session_id}: {exc}"
+            )
             return []
 
     def _fetch_participants(self, meet_session_id: str) -> list[dict]:
@@ -282,6 +290,7 @@ class MeetClient:
             list[dict[str, Any]]: A list of raw participant dictionaries from the API.
         """
         try:
+            logger.debug(f"Fetching participants for session: {meet_session_id}")
             response = (
                 self.meet.conferenceRecords()
                 .participants()
@@ -289,7 +298,10 @@ class MeetClient:
                 .execute()
             )
             return response.get("participants", [])
-        except HttpError:
+        except HttpError as exc:
+            logger.error(
+                f"Error fetching participants for session {meet_session_id}: {exc}"
+            )
             return []
 
     # --- Private Methods (Mapping) ---
@@ -308,6 +320,7 @@ class MeetClient:
         Returns:
             MeetParticipant: An initialized attendee model with descriptive attributes.
         """
+        logger.debug("Mapping raw participant data...")
         user_type = UserType.ANONYMOUS
         user_id = None
         display_name = "Unknown Participant"
@@ -353,6 +366,7 @@ class MeetClient:
         Returns:
             MeetRecording: A structured model containing the recording's life cycle details.
         """
+        logger.debug("Mapping raw recording data...")
         drive_id = raw_recording_data.get("driveDestination", {}).get("file")
         return MeetRecording(
             recording_id=raw_recording_data.get("name"),
@@ -376,6 +390,7 @@ class MeetClient:
         Returns:
             MeetTranscript: A validated model summarizing the transcript artifact.
         """
+        logger.debug("Mapping raw transcript data...")
         docs_id = raw_transcript_data.get("docsDestination", {}).get("document")
         return MeetTranscript(
             transcript_id=raw_transcript_data.get("name"),

--- a/mcp_servers/google_calendar/app/schemas.py
+++ b/mcp_servers/google_calendar/app/schemas.py
@@ -1,0 +1,155 @@
+from typing import Annotated, Literal, Optional
+from pydantic import BaseModel, Field
+
+from .calendar.schemas import CalendarEvent
+from .meet.schemas import MeetParticipant, MeetRecording, MeetSession, MeetTranscript
+
+
+class BaseResponse(BaseModel):
+    """
+    Base response model for all Google Calendar and Meet tools.
+    """
+
+    execution_status: Annotated[
+        Literal["success", "error"],
+        Field(
+            description="The status of the execution.",
+        ),
+    ]
+    execution_message: Annotated[
+        str,
+        Field(
+            default="Execution completed successfully.",
+            description="Detailed message about the execution or error description.",
+        ),
+    ]
+
+
+class ListCalendarEventsRequest(BaseModel):
+    max_events: Annotated[
+        int,
+        Field(
+            default=10,
+            description="The maximum number of events to return.",
+        ),
+    ]
+    date_min: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Lower bound date filter (YYYY-MM-DD).",
+        ),
+    ]
+    time_min: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Lower bound time filter (HH:MM:SSZ).",
+        ),
+    ]
+    date_max: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Upper bound date filter (YYYY-MM-DD).",
+        ),
+    ]
+    time_max: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Upper bound time filter (HH:MM:SSZ).",
+        ),
+    ]
+    query: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description=(
+                "Free text search terms to find events. Matches are found across multiple fields "
+                "including the event summary (title), description, location, organizer, and attendees. "
+                "Examples: 'AI architecture sync' or 'jane.doe@example.com'."
+            ),
+        ),
+    ]
+
+
+class ListCalendarEventsResponse(BaseResponse):
+    events: Annotated[
+        list[CalendarEvent],
+        Field(
+            default_factory=list,
+        ),
+    ]
+
+
+class ListMeetSessionsRequest(BaseModel):
+    meeting_code: Annotated[
+        str,
+        Field(
+            description="The 10-letter Google Meet code (e.g., 'abc-defg-hij').",
+        ),
+    ]
+
+
+class ListMeetSessionsResponse(BaseResponse, ListMeetSessionsRequest):
+    sessions: Annotated[
+        list[MeetSession],
+        Field(
+            default_factory=list,
+        ),
+    ]
+
+
+class ListMeetParticipantsRequest(BaseModel):
+    meet_session_id: Annotated[
+        str,
+        Field(
+            description="Unique Meet session ID (e.g., 'conferenceRecords/abc-123-xyz').",
+        ),
+    ]
+
+
+class ListMeetParticipantsResponse(BaseResponse, ListMeetParticipantsRequest):
+    participants: Annotated[
+        list[MeetParticipant],
+        Field(
+            default_factory=list,
+        ),
+    ]
+
+
+class GetMeetRecordingRequest(BaseModel):
+    recording_id: Annotated[
+        str,
+        Field(
+            description="The unique recording ID.",
+        ),
+    ]
+
+
+class GetMeetRecordingResponse(BaseResponse, GetMeetRecordingRequest):
+    recording: Annotated[
+        Optional[MeetRecording],
+        Field(
+            default=None,
+        ),
+    ]
+
+
+class GetMeetTranscriptRequest(BaseModel):
+    transcript_id: Annotated[
+        str,
+        Field(
+            description="The canonical resource ID of the transcript.",
+        ),
+    ]
+
+
+class GetMeetTranscriptResponse(BaseResponse, GetMeetTranscriptRequest):
+    transcript: Annotated[
+        Optional[MeetTranscript],
+        Field(
+            default=None,
+        ),
+    ]

--- a/mcp_servers/google_calendar/app/security.py
+++ b/mcp_servers/google_calendar/app/security.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Sequence
+from typing import Optional
 
 import httpx
 from google.oauth2.credentials import Credentials
@@ -57,13 +57,10 @@ class GoogleCalendarTokenVerifier(TokenVerifier):
         return None
 
 
-def create_events_client(*, scopes: Optional[Sequence[str]] = None) -> EventsClient:
+def create_events_client() -> EventsClient:
     """Factory to create an EventsClient using the current authenticated token.
 
     Extracts the token from the MCP auth context and builds authorized credentials.
-
-    Args:
-        scopes (Optional[Sequence[str]]): Optional specific scopes for the client.
 
     Returns:
         EventsClient: An initialized client for Google Calendar and Meet.
@@ -72,6 +69,10 @@ def create_events_client(*, scopes: Optional[Sequence[str]] = None) -> EventsCli
     if not token_obj or not token_obj.token:
         raise RuntimeError("No access token provided in request context")
 
-    creds = Credentials(token=token_obj.token, scopes=scopes)
+    # required_scopes is defined as an immutable tuple in the global config.
+    # We cast it to a list here to satisfy the google.oauth2.credentials Credentials signature.
+    creds = Credentials(
+        token=token_obj.token, scopes=list(CALENDAR_API_CONFIG.required_scopes)
+    )
 
     return EventsClient(creds)

--- a/mcp_servers/google_calendar/app/security.py
+++ b/mcp_servers/google_calendar/app/security.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Optional, Sequence
+
+import httpx
+from google.oauth2.credentials import Credentials
+from mcp.server.auth.middleware.auth_context import get_access_token
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+
+from .config import CALENDAR_API_CONFIG
+from .connector import EventsClient
+
+logger = logging.getLogger(__name__)
+
+
+class GoogleCalendarTokenVerifier(TokenVerifier):
+    """
+    Validates Google OAuth access tokens for authenticated MCP requests.
+    """
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        """
+        Verifies a Google OAuth bearer token and converts it into an MCP access token.
+
+        Args:
+            token (str): The Google OAuth access token provided by the client for
+                the current authenticated request.
+
+        Returns:
+            Optional[AccessToken]: A validated MCP access token or None if validation fails.
+        """
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    f"{CALENDAR_API_CONFIG.google_token_info_url}?access_token={token}"
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    token_scopes = data.get("scope", "").split()
+
+                    # Validate that required scopes are present
+                    required = set(CALENDAR_API_CONFIG.required_scopes)
+                    provided = set(token_scopes)
+
+                    if not required.issubset(provided):
+                        missing = required - provided
+                        logger.warning(f"Token missing required scopes: {missing}")
+                        return None
+
+                    return AccessToken(
+                        token=token,
+                        client_id=data.get("aud", "unknown"),
+                        scopes=token_scopes,
+                    )
+        except Exception:
+            logger.exception("Error verifying Google OAuth token")
+            pass
+        return None
+
+
+def create_events_client(*, scopes: Optional[Sequence[str]] = None) -> EventsClient:
+    """Factory to create an EventsClient using the current authenticated token.
+
+    Extracts the token from the MCP auth context and builds authorized credentials.
+
+    Args:
+        scopes (Optional[Sequence[str]]): Optional specific scopes for the client.
+
+    Returns:
+        EventsClient: An initialized client for Google Calendar and Meet.
+    """
+    token_obj = get_access_token()
+    if not token_obj or not token_obj.token:
+        raise RuntimeError("No access token provided in request context")
+
+    creds = Credentials(token=token_obj.token, scopes=scopes)
+
+    return EventsClient(creds)

--- a/mcp_servers/google_calendar/app/security.py
+++ b/mcp_servers/google_calendar/app/security.py
@@ -1,5 +1,5 @@
-import logging
 from typing import Optional
+from loguru import logger
 
 import httpx
 from google.oauth2.credentials import Credentials
@@ -8,8 +8,6 @@ from mcp.server.auth.provider import AccessToken, TokenVerifier
 
 from .config import CALENDAR_API_CONFIG
 from .connector import EventsClient
-
-logger = logging.getLogger(__name__)
 
 
 class GoogleCalendarTokenVerifier(TokenVerifier):

--- a/mcp_servers/google_calendar/tests/test_meet_client.py
+++ b/mcp_servers/google_calendar/tests/test_meet_client.py
@@ -34,8 +34,7 @@ def _make_http_error(status_code: int) -> HttpError:
 
 def test_meet_client_init(mock_build):
     creds = MagicMock()
-    client = MeetClient(creds)
-    assert client.creds is creds
+    _ = MeetClient(creds)
     mock_build.assert_called_once()
 
 

--- a/mcp_servers/google_calendar/tests/test_schemas.py
+++ b/mcp_servers/google_calendar/tests/test_schemas.py
@@ -1,0 +1,84 @@
+import pytest
+from pydantic import ValidationError
+
+from mcp_servers.google_calendar.app.schemas import (
+    BaseResponse,
+    ListCalendarEventsRequest,
+    ListCalendarEventsResponse,
+    ListMeetSessionsRequest,
+    ListMeetSessionsResponse,
+    ListMeetParticipantsRequest,
+    ListMeetParticipantsResponse,
+    GetMeetRecordingRequest,
+    GetMeetRecordingResponse,
+    GetMeetTranscriptRequest,
+    GetMeetTranscriptResponse,
+)
+
+# -----------------------------------------------------------------------
+# Inheritance Tests
+# -----------------------------------------------------------------------
+
+
+def test_responses_inherit_from_base_response():
+    """Ensure all response models inherit from BaseResponse."""
+    assert issubclass(ListCalendarEventsResponse, BaseResponse)
+    assert issubclass(ListMeetSessionsResponse, BaseResponse)
+    assert issubclass(ListMeetParticipantsResponse, BaseResponse)
+    assert issubclass(GetMeetRecordingResponse, BaseResponse)
+    assert issubclass(GetMeetTranscriptResponse, BaseResponse)
+
+
+def test_responses_inherit_from_request_eco_params():
+    """Ensure that the required specific response models inherit from their respective requests for parameter echoing."""
+    assert issubclass(ListMeetSessionsResponse, ListMeetSessionsRequest)
+    assert issubclass(ListMeetParticipantsResponse, ListMeetParticipantsRequest)
+    assert issubclass(GetMeetRecordingResponse, GetMeetRecordingRequest)
+    assert issubclass(GetMeetTranscriptResponse, GetMeetTranscriptRequest)
+
+
+# -----------------------------------------------------------------------
+# Validation and Default Value Edge Cases
+# -----------------------------------------------------------------------
+
+
+def test_base_response_validation():
+    """Test that BaseResponse validates execution_status correctly."""
+    # Invalid status should raise ValidationError
+    with pytest.raises(ValidationError, match="Input should be 'success' or 'error'"):
+        _ = BaseResponse(execution_status="pending")  # type: ignore
+
+    # Default execution_message is provided
+    resp = BaseResponse(execution_status="success")
+    assert resp.execution_message == "Execution completed successfully."
+    assert resp.execution_status == "success"
+
+
+def test_list_calendar_events_request_defaults():
+    req = ListCalendarEventsRequest()
+    assert req.max_events == 10
+    assert req.date_min is None
+    assert req.query is None
+
+
+def test_list_meet_sessions_response_echo():
+    """Test that creating a response requires the inherited request fields."""
+    # missing meeting_code
+    with pytest.raises(ValidationError, match="meeting_code"):
+        _ = ListMeetSessionsResponse(execution_status="error")
+
+    # valid creation
+    resp = ListMeetSessionsResponse(
+        execution_status="success", meeting_code="abc-123-xyz"
+    )
+    assert resp.meeting_code == "abc-123-xyz"
+    assert resp.sessions == []  # default_factory validates correctly
+
+
+def test_get_meet_recording_nullability():
+    """Test that nullable properties accept None."""
+    resp = GetMeetRecordingResponse(
+        execution_status="success", recording_id="rec-123", recording=None
+    )
+    assert resp.recording is None
+    assert resp.recording_id == "rec-123"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ mcp_calendar = [
     "google-auth-oauthlib>=1.2.0",
     "httpx>=0.27.0",
     "loguru>=0.7.3",
+    "mcp>=1.26.0",
     "pydantic>=2.5.3",
     "pydantic-settings>=2.13.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2343,6 +2343,7 @@ mcp-calendar = [
     { name = "google-auth-oauthlib" },
     { name = "httpx" },
     { name = "loguru" },
+    { name = "mcp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
@@ -2396,6 +2397,7 @@ mcp-calendar = [
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "mcp", specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.5.3" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
 ]


### PR DESCRIPTION
# Google Calendar & Meet MCP Server Implementation

**Summary**
Implementation of the Google Calendar (v3) and Meet (v2) MCP Server, wrapping the existing API clients into a stateless and heavily typed `FastMCP` interface ready for the AI Agent.

**Key Changes:**
1. **Pydantic Validation & Echoing (`schemas.py`)**: Defined strict input/output models. Configured a `BaseResponse` with error wrapping (`execution_status`) and multiple inheritance to execute "Parameter Echoing" (returning request inputs on the response for LLM context preservation).
2. **Observability (`loguru`)**: Purged standard `logging`. Implemented tiered telemetry across all layers (DEBUG for parsing/fetching, INFO for the `EventsClient` Connector/tools, and ERROR for `HttpError` fallbacks).
3. **Cloud Run Containerization (`Dockerfile`)**: Configured Cloud Run port `8080` exposition and astral's `uv sync --locked` for reproducible builds. Added `main.py` entrypoint.
4. **`Makefile` Inteegration**: Added Make commands to test and execute the server locally
5. **Testing Expansion**: Created `tests/test_schemas.py` asserting runtime inheritance rules. Fixed dead code and ran Ruff/Pytest 100% cleanly.

**How to test:**
```bash
make verify-calendar-ci
make run-calendar-mcp-locally
