### PR TITLE
MCP Servers / Google Calendar / Fix Deployment - Add dateutil library to the uv group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ mcp_calendar = [
     "mcp>=1.26.0",
     "pydantic>=2.5.3",
     "pydantic-settings>=2.13.1",
+    "python-dateutil>=2.9.0.post0",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -2346,6 +2346,7 @@ mcp-calendar = [
     { name = "mcp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-dateutil" },
 ]
 mcp-drive = [
     { name = "google-api-python-client" },
@@ -2400,6 +2401,7 @@ mcp-calendar = [
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "pydantic", specifier = ">=2.5.3" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
 ]
 mcp-drive = [
     { name = "google-api-python-client", specifier = ">=2.0.0" },


### PR DESCRIPTION
In order to the CloudRun instance to run successfully, an extra library needs to be added.