### PR TITLE
AI Agent / Basic Agent / Set MCP URLs as env vars instead of hardcoded values in Config classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 PROJECT_ID?=p-dev-gce-60pf # ?= is used to set a default value if the variable is not set in the .env file
 REGION?=us-central1
-BIGQUERY_URL?=mock-bigquery-url 
-DRIVE_URL?=mock-drive-url
+BIGQUERY_URL?=http://localhost:8080
+DRIVE_URL?=http://localhost:8081
+GCS_URL?=http://localhost:8082
+BIGQUERY_PROD_URL?=https://bigquery-mcp-server-753988132239.us-central1.run.app
+DRIVE_PROD_URL?=https://drive-mcp-server-753988132239.us-central1.run.app
+GCS_PROD_URL?=https://gcs-mcp-server-753988132239.us-central1.run.app
 GOOGLE_AUTH_ID?=mock-GE-drive-auth-resource-id
 ### General Commands ###
 
@@ -58,7 +62,7 @@ deploy-agent:
 		--entrypoint-object=app \
 		--requirements-file=./agent/core_agent/requirements.txt \
 		--service-account=adk-agent@p-dev-gce-60pf.iam.gserviceaccount.com \
-		--set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${REGION},MODEL_ARMOR_TEMPLATE_ID=security-template,BIGQUERY_URL=${BIGQUERY_URL},DRIVE_URL=${DRIVE_URL},GEMINI_GOOGLE_AUTH_ID=${GOOGLE_AUTH_ID}"
+		--set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${REGION},MODEL_ARMOR_TEMPLATE_ID=security-template,BIGQUERY_URL=${BIGQUERY_PROD_URL},DRIVE_URL=${DRIVE_PROD_URL},GCS_URL=${GCS_PROD_URL},GEMINI_GOOGLE_AUTH_ID=${GOOGLE_AUTH_ID}"
 	rm agent/core_agent/requirements.txt
 
 verify-agent-ci:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 PROJECT_ID?=p-dev-gce-60pf # ?= is used to set a default value if the variable is not set in the .env file
 REGION?=us-central1
-BIGQUERY_URL?=http://localhost:8080
-DRIVE_URL?=http://localhost:8081
-GCS_URL?=http://localhost:8082
 BIGQUERY_PROD_URL?=https://bigquery-mcp-server-753988132239.us-central1.run.app
 DRIVE_PROD_URL?=https://drive-mcp-server-753988132239.us-central1.run.app
 GCS_PROD_URL?=https://gcs-mcp-server-753988132239.us-central1.run.app

--- a/agent/core_agent/config.py
+++ b/agent/core_agent/config.py
@@ -289,7 +289,7 @@ class MCPServersConfig(BaseSettings):
     BIGQUERY_URL: Annotated[
         str,
         Field(
-            default="https://bigquery-mcp-server-753988132239.us-central1.run.app",
+            default="http://localhost:8080",
             description="BigQuery MCP Server URL, uses a streamable http connection",
         ),
     ]
@@ -406,7 +406,7 @@ class MCPServersConfig(BaseSettings):
     GCS_URL: Annotated[
         str,
         Field(
-            default="https://gcs-mcp-server-753988132239.us-central1.run.app",
+            default="http://localhost:8082",
             description="GCS MCP Server URL, uses a streamable http connection. Leave empty to disable.",
         ),
     ]

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -27,6 +27,16 @@ def test_gcp_config_override():
         assert config.REGION == "europe-west1"
 
 
+def test_mcp_servers_config_defaults_to_localhost_urls():
+    """Test that MCP server URLs default to local localhost endpoints."""
+    with patch.dict(os.environ, clear=True):
+        config = MCPServersConfig()
+
+    assert config.BIGQUERY_URL == "http://localhost:8080"
+    assert config.DRIVE_URL == "http://localhost:8081"
+    assert config.GCS_URL == "http://localhost:8082"
+
+
 def test_agent_config_validation():
     """Test that AgentConfig enforces data types and constraints."""
     with patch.dict(os.environ, clear=True):

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
@@ -5,6 +5,7 @@ substitutions:
   _AGENT_SA: "adk-agent"
   _BIGQUERY_URL: "https://bigquery-mcp-server-753988132239.us-central1.run.app"
   _DRIVE_URL: "https://drive-mcp-server-753988132239.us-central1.run.app"
+  _GCS_URL: "https://gcs-mcp-server-753988132239.us-central1.run.app"
   _GE_APP_ID: "newgeapp_1773239361913"
   _GE_REGION: "global"
   _GE_AGENT_DESCRIPTION: "Agent capable of searching and retrieving information from Google Drive, GCP and GCS using user's credentials"
@@ -108,7 +109,7 @@ steps:
           --entrypoint-object=app \
           --requirements-file=./agent/core_agent/requirements.txt \
           --service-account=${_AGENT_SA}@${PROJECT_ID}.iam.gserviceaccount.com \
-          --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GEMINI_GOOGLE_AUTH_ID=$$GEMINI_GOOGLE_AUTH_ID" 2>&1 | tee deploy_output.txt
+          --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GCS_URL=${_GCS_URL},GEMINI_GOOGLE_AUTH_ID=$$GEMINI_GOOGLE_AUTH_ID" 2>&1 | tee deploy_output.txt
         
         grep -o "reasoningEngines/[0-9]*" deploy_output.txt | tail -n 1 | cut -d'/' -f2 > /workspace/adk_resource.txt
         echo "Captured ADK_RESOURCE_ID: $(cat /workspace/adk_resource.txt)"


### PR DESCRIPTION
- agent/core_agent/config.py: changed the default MCP server URLs so the agent points to local services by default instead of production.

- Makefile: updated the default MCP URL variables to localhost values and separated deploy-time production URLs from local defaults.

- Makefile (deploy-agent): added explicit production MCP URLs to the deployment environment variables, including GCS_URL.

- terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml: updated the Cloud Build deploy step to pass the production GCS MCP URL as an env var.

- agent/tests/test_config.py: added a test to verify the MCP config defaults now resolve to the expected localhost ports.