### PR TITLE
feat(ekb): modify GCS storage path structure

### DIFF
--- a/docs/Data-Pipelines/Enterprise-Knowledge-Base/Design.md
+++ b/docs/Data-Pipelines/Enterprise-Knowledge-Base/Design.md
@@ -162,12 +162,12 @@ Documents are routed to domain-specific buckets with the following internal stru
 
 **Folder Structure within each bucket:**
 ```
-/{tier}/
-  {project_name}/
+/{project_name}/
+  {tier}/
     {uploader_email_prefix}/
       {filename}
 ```
-*Example: `gs://kb-it/client-confidential/project-alpha/maria.gutierrez/architecture.pdf`*
+*Example: `gs://kb-it/project-alpha/client-confidential/maria.gutierrez/architecture.pdf`*
 
 ### Security Rationale: IAM & Group-Based ACLs
 Access to domain buckets is managed via **Google Groups** mapped to `project` and `tier`.

--- a/docs/Data-Pipelines/Enterprise-Knowledge-Base/orchestration.md
+++ b/docs/Data-Pipelines/Enterprise-Knowledge-Base/orchestration.md
@@ -1,6 +1,6 @@
 # Document Classification Orchestration
 
-The `ClassificationPipeline.run()` method serves as the central entry point for the Enterprise Knowledge Base document processing workflow. It orchestrates multiple specialized services to transform a raw document into a classified, secured, and versioned asset.
+The `KBIngestionPipeline.run()` method serves as the master entry point for the Enterprise Knowledge Base document processing workflow. It orchestrates both the `ClassificationPipeline` and the `RAGIngestion` service to transform a raw document into a classified, secured, and vectorized asset.
 
 ## Workflow Overview
 
@@ -10,7 +10,8 @@ The orchestration follows a strictly sequential flow:
 2.  **DLP Gate**: Scans the document for sensitive data (PII, secrets). If high-risk content is found, it creates a de-identified/masked version.
 3.  **Contextual Classification**: Uses Gemini (Vertex AI) to analyze the (possibly masked) document and determine its final security tier and business domain.
 4.  **File Routing**: Moves the original and masked files from the landing zone to the final domain-specific buckets based on the classification results.
-5.  **Persistence**: Records the final URIs, classification metadata, and versioning state in BigQuery.
+5.  **Metadata Persistence**: Records the final URIs, classification metadata, and versioning state in BigQuery.
+6.  **RAG Ingestion & Vectorization**: Parses the processed document into semantic chunks, stages them in BigQuery, and triggers ML vectorization.
 
 ## State Management
 
@@ -28,12 +29,15 @@ To ensure system resilience and data consistency:
 ## Usage Example
 
 ```python
-from pipelines.enterprise_knowledge_base import ClassificationPipeline
+from pipelines.enterprise_knowledge_base.orchestrator import KBIngestionPipeline
+from pipelines.enterprise_knowledge_base.schemas import OrchestratorRunRequest
 
-pipeline = ClassificationPipeline()
-result = pipeline.run("gs://landing-zone-bucket/new_upload.pdf")
+pipeline = KBIngestionPipeline(project_id="my-gcp-project")
+request = OrchestratorRunRequest(gcs_uri="gs://landing-zone-bucket/new_upload.pdf")
+result = pipeline.run(request)
 
 print(f"Final Domain: {result.final_domain}")
-print(f"Security Tier: {result.final_security_tier}")
-print(f"Sanitized URI: {result.final_sanitized_uri}") # Returns masked file if exists, else original destination
+print(f"Security Tier: {result.security_tier}")
+print(f"Processed URI: {result.gcs_uri}")
+print(f"Chunks Vectorized: {result.chunks_generated}")
 ```

--- a/docs/Data-Pipelines/Enterprise-Knowledge-Base/rag_ingestion.md
+++ b/docs/Data-Pipelines/Enterprise-Knowledge-Base/rag_ingestion.md
@@ -37,8 +37,8 @@ Standard BigQuery insertions (`insert_rows_json`) place data in a streaming buff
 > [!TIP]
 > Always use `load_table_from_json` (Load Jobs). This writes directly to managed storage, making the rows immediately available for vectorization.
 
-### 3. URI Normalization
-Use `NORMALIZE(gcs_uri)` in all BigQuery SQL queries to handle hidden spaces or different Unicode representations of file paths.
+### 3. URI Normalization & Deterministic IDs
+Use `NORMALIZE(gcs_uri)` in all BigQuery SQL queries to handle hidden spaces or different Unicode representations of file paths. The pipeline relies on a deterministic UUIDv5 generated from the NFC-normalized GCS URI to ensure `document_id` consistency between the `documents_metadata` and `documents_chunks` tables.
 
 ## Troubleshooting
 - **0 affected rows in UPDATE**: Check if the data is stuck in the streaming buffer (if Load Jobs were not used).

--- a/docs/Data-Pipelines/Enterprise-Knowledge-Base/routing_and_persistence.md
+++ b/docs/Data-Pipelines/Enterprise-Knowledge-Base/routing_and_persistence.md
@@ -8,7 +8,7 @@ The routing logic is authoritative and follows the classification verdict produc
 
 ### Destination Path Construction
 The target URI is constructed as follows:
-`gs://kb-{domain}/{tier_label}/{project_name}/{uploader_email_prefix}/{filename}`
+`gs://kb-{domain}/{project_name}/{tier_label}/{uploader_email_prefix}/{filename}`
 
 - **domain**: One of the valid business domains (`it`, `finance`, `hr`, etc.).
 - **tier_label**: The slugified version of the security tier (e.g., `strictly-confidential` for Tier 5).

--- a/docs/Data-Pipelines/Enterprise-Knowledge-Base/routing_and_persistence.md
+++ b/docs/Data-Pipelines/Enterprise-Knowledge-Base/routing_and_persistence.md
@@ -29,7 +29,7 @@ Metadata is stored in the `knowledge_base` dataset, `documents_metadata` table.
 
 | Field | Type | Description |
 |---|---|---|
-| `document_id` | `STRING` | Unique UUID for the document record. |
+| `document_id` | `STRING` | Deterministic UUID (UUIDv5 of `NORMALIZE(NFC, gcs_uri)`) linking metadata and chunks. |
 | `gcs_uri` | `STRING` | The URI of the original document in the domain bucket (used for search/RAG). |
 | `filename` | `STRING` | Original filename. |
 | `classification_tier` | `INT64` | Numeric classification tier (1-5). |

--- a/notebooks/enterprise_knowledge_base/orchestrator_verification.ipynb
+++ b/notebooks/enterprise_knowledge_base/orchestrator_verification.ipynb
@@ -40,7 +40,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:08:42.902\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
+      "\u001b[32m2026-04-27 18:35:12.478\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
      ]
     },
     {
@@ -103,14 +103,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:10:02.018\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
+      "\u001b[32m2026-04-27 18:35:14.936\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
      ]
     },
     {
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -149,7 +149,7 @@
        "'gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,19 +169,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:10:11.767\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m37\u001b[0m - \u001b[1mTriggering KB Ingestion Pipeline for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:11.768\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m40\u001b[0m - \u001b[1mStep 1: Running Document Classification...\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:11.769\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m54\u001b[0m - \u001b[1mStarting pipeline orchestration for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:11.769\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_get_blob_metadata\u001b[0m:\u001b[36m190\u001b[0m - \u001b[34m\u001b[1mExtracting metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:11.769\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:11.769\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n"
+      "\u001b[32m2026-04-27 18:35:16.236\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m37\u001b[0m - \u001b[1mTriggering KB Ingestion Pipeline for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:16.236\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m40\u001b[0m - \u001b[1mStep 1: Running Document Classification...\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m54\u001b[0m - \u001b[1mStarting pipeline orchestration for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_get_blob_metadata\u001b[0m:\u001b[36m190\u001b[0m - \u001b[34m\u001b[1mExtracting metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n"
      ]
     },
     {
@@ -196,45 +196,44 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:10:12.220\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mdlp_trigger\u001b[0m:\u001b[36m158\u001b[0m - \u001b[1mTriggering DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:12.220\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m38\u001b[0m - \u001b[1mStarting DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:12.221\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36m_get_custom_keywords_config\u001b[0m:\u001b[36m209\u001b[0m - \u001b[34m\u001b[1mBuilding custom keywords config for inspection.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:13.519\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m66\u001b[0m - \u001b[1mDLP Job created: projects/ag-core-dev-fdx7/locations/global/dlpJobs/i-1804215816337867197\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:13.642\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:18.897\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:24.032\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:29.166\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:34.295\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:39.706\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:44.907\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:50.055\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m94\u001b[0m - \u001b[1mDLP findings detected: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:50.055\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_determine_tier\u001b[0m:\u001b[36m195\u001b[0m - \u001b[34m\u001b[1mDetermining risk tier from findings: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:50.055\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mcontextual_classification\u001b[0m:\u001b[36m138\u001b[0m - \u001b[1mStarting contextual classification for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:50.056\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:50.056\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:10:50.147\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gemini_service.service\u001b[0m:\u001b[36mclassify_document\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mClassifying document via Gemini: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.528\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mfile_routing\u001b[0m:\u001b[36m279\u001b[0m - \u001b[1mRouting files for domain: it, Tier: 4\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.528\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mcopy_blob\u001b[0m:\u001b[36m96\u001b[0m - \u001b[1mCopying blob from gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf to gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.528\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.529\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.725\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mdelete_blob\u001b[0m:\u001b[36m116\u001b[0m - \u001b[1mDeleting blob: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.725\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.930\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mingest_metadata_bq\u001b[0m:\u001b[36m326\u001b[0m - \u001b[1mPersisting versioned metadata to BQ for: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:02.930\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36mget_latest_version\u001b[0m:\u001b[36m108\u001b[0m - \u001b[1mChecking latest version for document: c6098455-cf86-5951-b607-c77ac9e0afc3\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:04.466\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m61\u001b[0m - \u001b[1mLoading metadata into BigQuery table: ag-core-dev-fdx7.knowledge_base.documents_metadata\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:05.387\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m77\u001b[0m - \u001b[1mStarted Load Job: 1503d472-9ff9-4de6-971f-d568de7cde65\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:07.469\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m84\u001b[0m - \u001b[1mBigQuery Load Job successful.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:07.470\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m93\u001b[0m - \u001b[1mPipeline completed successfully for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:07.470\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m42\u001b[0m - \u001b[1mClassification complete. Domain: it\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:07.470\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m45\u001b[0m - \u001b[1mStep 2: Running RAG Ingestion for gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf...\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:07.471\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m58\u001b[0m - \u001b[1mStarting end-to-end pipeline for: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:07.471\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mingest_document\u001b[0m:\u001b[36m88\u001b[0m - \u001b[1mStarting ingestion for document: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:09.892\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_clear_existing_chunks\u001b[0m:\u001b[36m321\u001b[0m - \u001b[1mCleared 0 existing chunks for: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:09.892\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_copy_to_staging\u001b[0m:\u001b[36m412\u001b[0m - \u001b[1mStaging document: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf -> gs://ag-core-dev-fdx7-rag-staging/ingested/8c63a0db/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:15.110\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mingest_document\u001b[0m:\u001b[36m111\u001b[0m - \u001b[1mSuccessfully staged 15 chunks to BigQuery.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:15.110\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_move_blob_to_processed\u001b[0m:\u001b[36m446\u001b[0m - \u001b[34m\u001b[1mMoving staging file ingested/8c63a0db/SoW - Innovation.pdf to processed/8c63a0db/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:15.420\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mgenerate_embeddings\u001b[0m:\u001b[36m144\u001b[0m - \u001b[1mTriggering embedding generation for: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:15.421\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_execute_embedding_query\u001b[0m:\u001b[36m220\u001b[0m - \u001b[34m\u001b[1mExecuting BQ ML Query: \n",
+      "\u001b[32m2026-04-27 18:35:16.888\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mdlp_trigger\u001b[0m:\u001b[36m158\u001b[0m - \u001b[1mTriggering DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:16.889\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m38\u001b[0m - \u001b[1mStarting DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:16.889\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36m_get_custom_keywords_config\u001b[0m:\u001b[36m209\u001b[0m - \u001b[34m\u001b[1mBuilding custom keywords config for inspection.\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:17.858\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m66\u001b[0m - \u001b[1mDLP Job created: projects/ag-core-dev-fdx7/locations/global/dlpJobs/i-4452847835047062127\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:17.998\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:23.158\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:28.381\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:33.810\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:38.931\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:44.058\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:49.191\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m94\u001b[0m - \u001b[1mDLP findings detected: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:49.192\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_determine_tier\u001b[0m:\u001b[36m195\u001b[0m - \u001b[34m\u001b[1mDetermining risk tier from findings: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:49.192\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mcontextual_classification\u001b[0m:\u001b[36m138\u001b[0m - \u001b[1mStarting contextual classification for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:49.192\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:49.193\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:35:49.310\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gemini_service.service\u001b[0m:\u001b[36mclassify_document\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mClassifying document via Gemini: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.374\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mfile_routing\u001b[0m:\u001b[36m279\u001b[0m - \u001b[1mRouting files for domain: it, Tier: 4\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.375\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mcopy_blob\u001b[0m:\u001b[36m96\u001b[0m - \u001b[1mCopying blob from gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf to gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.375\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.376\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.566\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mdelete_blob\u001b[0m:\u001b[36m116\u001b[0m - \u001b[1mDeleting blob: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.567\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.693\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mingest_metadata_bq\u001b[0m:\u001b[36m326\u001b[0m - \u001b[1mPersisting versioned metadata to BQ for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:02.694\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36mget_latest_version\u001b[0m:\u001b[36m108\u001b[0m - \u001b[1mChecking latest version for document: 89eb7bfb-d849-549f-88bf-62e37bf99f65\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:04.201\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m61\u001b[0m - \u001b[1mLoading metadata into BigQuery table: ag-core-dev-fdx7.knowledge_base.documents_metadata\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:05.104\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m77\u001b[0m - \u001b[1mStarted Load Job: b04d2a66-3ea2-4d26-8f29-9b38906b9589\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:07.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m84\u001b[0m - \u001b[1mBigQuery Load Job successful.\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:07.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m93\u001b[0m - \u001b[1mPipeline completed successfully for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:07.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m42\u001b[0m - \u001b[1mClassification complete. Domain: it\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:07.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m45\u001b[0m - \u001b[1mStep 2: Running RAG Ingestion for gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf...\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:07.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m58\u001b[0m - \u001b[1mStarting end-to-end pipeline for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:07.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mingest_document\u001b[0m:\u001b[36m88\u001b[0m - \u001b[1mStarting ingestion for document: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:10.106\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_clear_existing_chunks\u001b[0m:\u001b[36m321\u001b[0m - \u001b[1mCleared 0 existing chunks for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:10.106\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_copy_to_staging\u001b[0m:\u001b[36m412\u001b[0m - \u001b[1mStaging document: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf -> gs://ag-core-dev-fdx7-rag-staging/ingested/79d107e1/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:14.126\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mingest_document\u001b[0m:\u001b[36m111\u001b[0m - \u001b[1mSuccessfully staged 15 chunks to BigQuery.\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:14.127\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_move_blob_to_processed\u001b[0m:\u001b[36m446\u001b[0m - \u001b[34m\u001b[1mMoving staging file ingested/79d107e1/SoW - Innovation.pdf to processed/79d107e1/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:14.436\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mgenerate_embeddings\u001b[0m:\u001b[36m144\u001b[0m - \u001b[1mTriggering embedding generation for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:14.436\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_execute_embedding_query\u001b[0m:\u001b[36m220\u001b[0m - \u001b[34m\u001b[1mExecuting BQ ML Query: \n",
       "            UPDATE `ag-core-dev-fdx7.knowledge_base.documents_chunks` AS target\n",
       "            SET \n",
       "              target.embedding = source.ml_generate_embedding_result,\n",
@@ -253,9 +252,9 @@
       "            WHERE target.chunk_id = source.chunk_id\n",
       "              AND NORMALIZE(target.gcs_uri) = NORMALIZE(@gcs_uri);\n",
       "        \u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:18.809\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_validate_embedding_results\u001b[0m:\u001b[36m245\u001b[0m - \u001b[1mSuccessfully generated embeddings for ALL chunks: gs://kb-it/confidential/orchestration-test/emmanuel.amador/SoW - Innovation.pdf. Rows affected: 15 (Attempt 1)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:19.722\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_verify_embeddings_persist\u001b[0m:\u001b[36m294\u001b[0m - \u001b[1mVerified 15/15 chunks have embeddings in BigQuery.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:11:19.723\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mPipeline finished successfully. Chunks: 15\u001b[0m\n"
+      "\u001b[32m2026-04-27 18:36:19.562\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_validate_embedding_results\u001b[0m:\u001b[36m245\u001b[0m - \u001b[1mSuccessfully generated embeddings for ALL chunks: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf. Rows affected: 15 (Attempt 1)\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:20.460\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_verify_embeddings_persist\u001b[0m:\u001b[36m294\u001b[0m - \u001b[1mVerified 15/15 chunks have embeddings in BigQuery.\u001b[0m\n",
+      "\u001b[32m2026-04-27 18:36:20.461\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mPipeline finished successfully. Chunks: 15\u001b[0m\n"
      ]
     },
     {
@@ -272,6 +271,13 @@
     "orchestrator.run(landing_uri)\n",
     "print(\"\\n--- Pipeline Execution Complete ---\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/enterprise_knowledge_base/orchestrator_verification.ipynb
+++ b/notebooks/enterprise_knowledge_base/orchestrator_verification.ipynb
@@ -33,14 +33,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:35:12.478\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
+      "\u001b[32m2026-04-27 19:05:03.546\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
      ]
     },
     {
@@ -60,7 +60,7 @@
     "# Ensure project root is in path\n",
     "sys.path.append(\"../..\")\n",
     "\n",
-    "from pipelines.enterprise_knowledge_base.orchestrator import KBIngestionPipeline\n",
+    "from pipelines.enterprise_knowledge_base.orchestrator import KBIngestionPipeline, OrchestratorRunRequest\n",
     "\n",
     "# Configuration\n",
     "PROJECT_ID = \"ag-core-dev-fdx7\"\n",
@@ -70,7 +70,6 @@
     "\n",
     "orchestrator = KBIngestionPipeline(PROJECT_ID)\n",
     "storage_client = storage.Client()\n",
-    "bq_client = bigquery.Client()\n",
     "\n",
     "print(f\"Orchestrator initialized for project: {PROJECT_ID}\")"
    ]
@@ -86,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,14 +102,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:35:14.936\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
+      "\u001b[32m2026-04-27 19:11:41.958\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m__init__\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mInitialized RAGIngestion | CHUNK_SIZE: 1000 | OVERLAP: 100\u001b[0m\n"
      ]
     },
     {
@@ -122,8 +121,6 @@
     }
    ],
    "source": [
-    "pipeline = KBIngestionPipeline(PROJECT_ID)\n",
-    "\n",
     "# 1. Ingest\n",
     "local_path = \"../../SoW - Innovation.pdf\"\n",
     "metadata = {\n",
@@ -140,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -149,7 +146,7 @@
        "'gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -169,107 +166,75 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:35:16.236\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m37\u001b[0m - \u001b[1mTriggering KB Ingestion Pipeline for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:16.236\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m40\u001b[0m - \u001b[1mStep 1: Running Document Classification...\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m54\u001b[0m - \u001b[1mStarting pipeline orchestration for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_get_blob_metadata\u001b[0m:\u001b[36m190\u001b[0m - \u001b[34m\u001b[1mExtracting metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:16.237\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Triggering pipeline for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\n",
-      "\n"
+      "\u001b[32m2026-04-27 19:11:42.859\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m39\u001b[0m - \u001b[1mTriggering KB Ingestion Pipeline for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:42.860\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m42\u001b[0m - \u001b[1mStep 1: Running Document Classification...\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:42.860\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mStarting pipeline orchestration for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:42.860\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_get_blob_metadata\u001b[0m:\u001b[36m191\u001b[0m - \u001b[34m\u001b[1mExtracting metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:42.861\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:42.861\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\u001b[32m2026-04-27 18:35:16.888\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mdlp_trigger\u001b[0m:\u001b[36m158\u001b[0m - \u001b[1mTriggering DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:16.889\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m38\u001b[0m - \u001b[1mStarting DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:16.889\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36m_get_custom_keywords_config\u001b[0m:\u001b[36m209\u001b[0m - \u001b[34m\u001b[1mBuilding custom keywords config for inspection.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:17.858\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m66\u001b[0m - \u001b[1mDLP Job created: projects/ag-core-dev-fdx7/locations/global/dlpJobs/i-4452847835047062127\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:17.998\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:23.158\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:28.381\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:33.810\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:38.931\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:44.058\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:49.191\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m94\u001b[0m - \u001b[1mDLP findings detected: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:49.192\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_determine_tier\u001b[0m:\u001b[36m195\u001b[0m - \u001b[34m\u001b[1mDetermining risk tier from findings: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:49.192\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mcontextual_classification\u001b[0m:\u001b[36m138\u001b[0m - \u001b[1mStarting contextual classification for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:49.192\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:49.193\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:35:49.310\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gemini_service.service\u001b[0m:\u001b[36mclassify_document\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mClassifying document via Gemini: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.374\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mfile_routing\u001b[0m:\u001b[36m279\u001b[0m - \u001b[1mRouting files for domain: it, Tier: 4\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.375\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mcopy_blob\u001b[0m:\u001b[36m96\u001b[0m - \u001b[1mCopying blob from gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf to gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.375\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.376\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.566\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mdelete_blob\u001b[0m:\u001b[36m116\u001b[0m - \u001b[1mDeleting blob: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.567\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.693\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mingest_metadata_bq\u001b[0m:\u001b[36m326\u001b[0m - \u001b[1mPersisting versioned metadata to BQ for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:02.694\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36mget_latest_version\u001b[0m:\u001b[36m108\u001b[0m - \u001b[1mChecking latest version for document: 89eb7bfb-d849-549f-88bf-62e37bf99f65\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:04.201\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m61\u001b[0m - \u001b[1mLoading metadata into BigQuery table: ag-core-dev-fdx7.knowledge_base.documents_metadata\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:05.104\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m77\u001b[0m - \u001b[1mStarted Load Job: b04d2a66-3ea2-4d26-8f29-9b38906b9589\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:07.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36minsert_metadata\u001b[0m:\u001b[36m84\u001b[0m - \u001b[1mBigQuery Load Job successful.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:07.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m93\u001b[0m - \u001b[1mPipeline completed successfully for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:07.506\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m42\u001b[0m - \u001b[1mClassification complete. Domain: it\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:07.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m45\u001b[0m - \u001b[1mStep 2: Running RAG Ingestion for gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf...\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:07.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m58\u001b[0m - \u001b[1mStarting end-to-end pipeline for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:07.507\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mingest_document\u001b[0m:\u001b[36m88\u001b[0m - \u001b[1mStarting ingestion for document: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:10.106\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_clear_existing_chunks\u001b[0m:\u001b[36m321\u001b[0m - \u001b[1mCleared 0 existing chunks for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:10.106\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_copy_to_staging\u001b[0m:\u001b[36m412\u001b[0m - \u001b[1mStaging document: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf -> gs://ag-core-dev-fdx7-rag-staging/ingested/79d107e1/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:14.126\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mingest_document\u001b[0m:\u001b[36m111\u001b[0m - \u001b[1mSuccessfully staged 15 chunks to BigQuery.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:14.127\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_move_blob_to_processed\u001b[0m:\u001b[36m446\u001b[0m - \u001b[34m\u001b[1mMoving staging file ingested/79d107e1/SoW - Innovation.pdf to processed/79d107e1/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:14.436\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36mgenerate_embeddings\u001b[0m:\u001b[36m144\u001b[0m - \u001b[1mTriggering embedding generation for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:14.436\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_execute_embedding_query\u001b[0m:\u001b[36m220\u001b[0m - \u001b[34m\u001b[1mExecuting BQ ML Query: \n",
-      "            UPDATE `ag-core-dev-fdx7.knowledge_base.documents_chunks` AS target\n",
-      "            SET \n",
-      "              target.embedding = source.ml_generate_embedding_result,\n",
-      "              target.vectorized_at = CURRENT_TIMESTAMP()\n",
-      "            FROM (\n",
-      "              SELECT * FROM ML.GENERATE_EMBEDDING(\n",
-      "                MODEL `ag-core-dev-fdx7.knowledge_base.multimodal_embedding_model`,\n",
-      "                (\n",
-      "                  SELECT c.chunk_id, c.chunk_data AS content\n",
-      "                  FROM `ag-core-dev-fdx7.knowledge_base.documents_chunks` c\n",
-      "                  WHERE NORMALIZE(c.gcs_uri) = NORMALIZE(@gcs_uri)\n",
-      "                )\n",
-      "              )\n",
-      "              WHERE ml_generate_embedding_status = ''\n",
-      "            ) AS source\n",
-      "            WHERE target.chunk_id = source.chunk_id\n",
-      "              AND NORMALIZE(target.gcs_uri) = NORMALIZE(@gcs_uri);\n",
-      "        \u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:19.562\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_validate_embedding_results\u001b[0m:\u001b[36m245\u001b[0m - \u001b[1mSuccessfully generated embeddings for ALL chunks: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf. Rows affected: 15 (Attempt 1)\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:20.460\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.rag_ingestion.pipeline\u001b[0m:\u001b[36m_verify_embeddings_persist\u001b[0m:\u001b[36m294\u001b[0m - \u001b[1mVerified 15/15 chunks have embeddings in BigQuery.\u001b[0m\n",
-      "\u001b[32m2026-04-27 18:36:20.461\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.orchestrator\u001b[0m:\u001b[36mrun\u001b[0m:\u001b[36m55\u001b[0m - \u001b[1mPipeline finished successfully. Chunks: 15\u001b[0m\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "--- Pipeline Execution Complete ---\n"
+      "\u001b[32m2026-04-27 19:11:43.053\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mdlp_trigger\u001b[0m:\u001b[36m159\u001b[0m - \u001b[1mTriggering DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:43.054\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m38\u001b[0m - \u001b[1mStarting DLP scan for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:43.054\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36m_get_custom_keywords_config\u001b[0m:\u001b[36m209\u001b[0m - \u001b[34m\u001b[1mBuilding custom keywords config for inspection.\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:43.777\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36minspect_gcs_file\u001b[0m:\u001b[36m66\u001b[0m - \u001b[1mDLP Job created: projects/ag-core-dev-fdx7/locations/global/dlpJobs/i-6857005541962115804\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:43.886\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:49.025\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: PENDING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:54.151\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:11:59.754\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:04.866\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:10.091\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m104\u001b[0m - \u001b[1mWaiting for DLP Job... (Current state: RUNNING)\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:15.314\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.dlp_service.service\u001b[0m:\u001b[36mwait_for_job\u001b[0m:\u001b[36m94\u001b[0m - \u001b[1mDLP findings detected: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:15.315\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36m_determine_tier\u001b[0m:\u001b[36m196\u001b[0m - \u001b[34m\u001b[1mDetermining risk tier from findings: ['DATE', 'PERSON_NAME', 'EMAIL_ADDRESS']\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:15.315\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mcontextual_classification\u001b[0m:\u001b[36m139\u001b[0m - \u001b[1mStarting contextual classification for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:15.316\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mget_blob_metadata\u001b[0m:\u001b[36m31\u001b[0m - \u001b[1mExtracting detailed GCS metadata for: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:15.316\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:15.508\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gemini_service.service\u001b[0m:\u001b[36mclassify_document\u001b[0m:\u001b[36m41\u001b[0m - \u001b[1mClassifying document via Gemini: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.244\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mfile_routing\u001b[0m:\u001b[36m280\u001b[0m - \u001b[1mRouting files for domain: it, Tier: 4\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.245\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mcopy_blob\u001b[0m:\u001b[36m96\u001b[0m - \u001b[1mCopying blob from gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf to gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.245\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.246\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.382\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36mdelete_blob\u001b[0m:\u001b[36m116\u001b[0m - \u001b[1mDeleting blob: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.383\u001b[0m | \u001b[34m\u001b[1mDEBUG   \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.gcs_service.service\u001b[0m:\u001b[36m_parse_uri\u001b[0m:\u001b[36m132\u001b[0m - \u001b[34m\u001b[1mParsing GCS URI into dictionary: gs://ag-core-dev-fdx7-kb-landing-zone/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.576\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.pipeline\u001b[0m:\u001b[36mingest_metadata_bq\u001b[0m:\u001b[36m327\u001b[0m - \u001b[1mPersisting versioned metadata to BQ for: gs://kb-it/orchestration-test/confidential/emmanuel.amador/SoW - Innovation.pdf\u001b[0m\n",
+      "\u001b[32m2026-04-27 19:12:30.576\u001b[0m | \u001b[1mINFO    \u001b[0m | \u001b[36mpipelines.enterprise_knowledge_base.document_classification.bq_service.service\u001b[0m:\u001b[36mget_latest_version\u001b[0m:\u001b[36m108\u001b[0m - \u001b[1mChecking latest version for document: 7cb0dcd5-aaab-59a7-9f3a-02925af37bdd\u001b[0m\n"
      ]
     }
    ],
    "source": [
-    "print(f\"Triggering pipeline for: {landing_uri}\\n\")\n",
-    "orchestrator.run(landing_uri)\n",
-    "print(\"\\n--- Pipeline Execution Complete ---\")"
+    "request = OrchestratorRunRequest(gcs_uri=landing_uri)\n",
+    "resp = orchestrator.run(request)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OrchestratorRunResponse(gcs_uri='gs://kb-operations/orchestration-test/internal-use-only/emmanuel.amador/Carta_recomendación_CONUEE.pdf', chunks_generated=2, final_domain='operations', security_tier='internal-use-only')"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "resp"
    ]
   },
   {

--- a/pipelines/enterprise_knowledge_base/document_classification/pipeline.py
+++ b/pipelines/enterprise_knowledge_base/document_classification/pipeline.py
@@ -285,7 +285,7 @@ class ClassificationPipeline:
         filename = request.original_landing_uri.split("/")[-1]
         uploader_prefix = request.uploader_email.split("@")[0]
 
-        dest_base = f"gs://kb-{request.final_domain}/{tier_label}/{request.project_name}/{uploader_prefix}/"
+        dest_base = f"gs://kb-{request.final_domain}/{request.project_name}/{tier_label}/{uploader_prefix}/"
         final_original_uri = f"{dest_base}{filename}"
 
         # 1. Copy Original

--- a/pipelines/enterprise_knowledge_base/document_classification/pipeline.py
+++ b/pipelines/enterprise_knowledge_base/document_classification/pipeline.py
@@ -1,6 +1,7 @@
 from typing import Optional
 import fitz  # PyMuPDF
 import uuid
+import unicodedata
 from datetime import datetime, timezone
 from loguru import logger
 from .config import EKB_CONFIG
@@ -332,8 +333,9 @@ class ClassificationPipeline:
         filename = request.blob_metadata.filename
         gcs_uri = request.final_original_uri
 
-        identity_key = f"{project_id}/{filename}/{gcs_uri}"
-        doc_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, identity_key))
+        doc_id = str(
+            uuid.uuid5(uuid.NAMESPACE_URL, unicodedata.normalize("NFC", gcs_uri))
+        )
 
         # 2. Handle Versioning
         version_req = GetLatestVersionRequest(document_id=doc_id)

--- a/pipelines/enterprise_knowledge_base/orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/orchestrator.py
@@ -2,10 +2,12 @@ import sys
 from loguru import logger
 
 from .document_classification import ClassificationPipeline
+from .document_classification.config import EKB_CONFIG
 from .rag_ingestion import (
     IngestDocumentRequest,
     RAGIngestion,
 )
+from .schemas import OrchestratorRunRequest, OrchestratorRunResponse
 
 
 class KBIngestionPipeline:
@@ -25,20 +27,20 @@ class KBIngestionPipeline:
         self.classification_pipeline = ClassificationPipeline()
         self.rag_pipeline = RAGIngestion()
 
-    def run(self, gcs_uri: str) -> None:
+    def run(self, request: OrchestratorRunRequest) -> OrchestratorRunResponse:
         """Orchestrates the entire ingestion process end-to-end.
 
         Args:
-            gcs_uri: str -> The initial landing URI of the document.
+            request: OrchestratorRunRequest -> The request containing the landing URI.
 
         Returns:
-            None
+            OrchestratorRunResponse -> Results of the pipeline execution.
         """
-        logger.info(f"Triggering KB Ingestion Pipeline for: {gcs_uri}")
+        logger.info(f"Triggering KB Ingestion Pipeline for: {request.gcs_uri}")
 
         # 1. Execute Classification Pipeline
         logger.info("Step 1: Running Document Classification...")
-        class_resp = self.classification_pipeline.run(gcs_uri)
+        class_resp = self.classification_pipeline.run(request.gcs_uri)
         logger.info(f"Classification complete. Domain: {class_resp.final_domain}")
 
         # 2. Execute end-to-end RAG pipeline
@@ -60,6 +62,17 @@ class KBIngestionPipeline:
                 f"Pipeline finished with status: {ingest_resp.execution_status}"
             )
 
+        tier_label = EKB_CONFIG.TIER_TO_LABEL.get(
+            class_resp.final_security_tier, "unknown"
+        )
+
+        return OrchestratorRunResponse(
+            gcs_uri=class_resp.final_original_uri,
+            chunks_generated=ingest_resp.chunk_count,
+            final_domain=class_resp.final_domain,
+            security_tier=tier_label,
+        )
+
 
 if __name__ == "__main__":
     if len(sys.argv) < 3:
@@ -72,4 +85,6 @@ if __name__ == "__main__":
     input_uri = sys.argv[2]
 
     pipeline = KBIngestionPipeline(proj_id)
-    pipeline.run(input_uri)
+    run_req = OrchestratorRunRequest(gcs_uri=input_uri)
+    response = pipeline.run(run_req)
+    print(response.model_dump_json(indent=2))

--- a/pipelines/enterprise_knowledge_base/schemas.py
+++ b/pipelines/enterprise_knowledge_base/schemas.py
@@ -1,0 +1,29 @@
+from typing import Annotated, Literal
+from pydantic import BaseModel, Field
+
+
+class OrchestratorRunRequest(BaseModel):
+    """Request schema for the KB Orchestrator run method."""
+
+    gcs_uri: Annotated[
+        str, Field(description="The initial landing URI of the document")
+    ]
+
+
+class OrchestratorRunResponse(BaseModel):
+    """Response schema for the KB Orchestrator run method."""
+
+    gcs_uri: Annotated[
+        str, Field(description="The final unmasked GCS URI of the document")
+    ]
+    chunks_generated: Annotated[
+        int, Field(description="Number of chunks vectorized and stored")
+    ]
+    final_domain: Annotated[
+        Literal["it", "finance", "hr", "sales", "executives", "legal", "operations"],
+        Field(description="The determined business domain"),
+    ]
+    security_tier: Annotated[
+        str,
+        Field(description="The string label of the security tier (e.g., confidential)"),
+    ]

--- a/pipelines/enterprise_knowledge_base/tests/test_document_classification.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_document_classification.py
@@ -112,7 +112,7 @@ def test_dlp_trigger_with_findings_returns_masked(pipeline, mock_dlp, mock_gcs):
 def test_ingest_metadata_bq_versioning_first_upload(pipeline, mock_bq):
     """Verifies version 1 is assigned on the first upload of a document."""
     request = IngestMetadataBQRequest(
-        final_original_uri="gs://kb-hr/strictly-confidential/hr-data/admin/record.pdf",
+        final_original_uri="gs://kb-hr/hr-data/strictly-confidential/admin/record.pdf",
         final_sanitized_uri=None,
         llm_classification=ContextualClassificationResponse(
             final_classification_tier=5,
@@ -150,7 +150,7 @@ def test_ingest_metadata_bq_versioning_first_upload(pipeline, mock_bq):
 def test_ingest_metadata_bq_versioning_increment(pipeline, mock_bq):
     """Verifies version is incremented and old versions deprecated on re-upload."""
     request = IngestMetadataBQRequest(
-        final_original_uri="gs://kb-hr/confidential/hr-data/admin/record.pdf",
+        final_original_uri="gs://kb-hr/hr-data/confidential/admin/record.pdf",
         final_sanitized_uri=None,
         llm_classification=ContextualClassificationResponse(
             final_classification_tier=4,
@@ -269,7 +269,7 @@ def test_run_orchestrates_full_pipeline_successfully(
     assert result.final_domain == "it"
     assert result.final_security_tier == 1
     # Should return original destination URI because no masking occurred
-    assert result.final_sanitized_uri == "gs://kb-it/public/p1/u1/doc.pdf"
+    assert result.final_sanitized_uri == "gs://kb-it/p1/public/u1/doc.pdf"
 
     # Verify sequence
     mock_gcs.get_blob_metadata.assert_called()
@@ -362,5 +362,5 @@ def test_run_returns_masked_uri_when_sanitized(
     # Should return the final destination of the MASKED file
     assert (
         result.final_sanitized_uri
-        == "gs://kb-executives/strictly-confidential/top-secret/admin/secret_masked.txt"
+        == "gs://kb-executives/top-secret/strictly-confidential/admin/secret_masked.txt"
     )

--- a/pipelines/enterprise_knowledge_base/tests/test_rag_ingestion.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_rag_ingestion.py
@@ -42,7 +42,11 @@ def mock_bq():
     ) as mock:
         mock_client = mock.return_value
         mock_query_job = MagicMock()
+
+        # By default, return empty result to pass _is_document_processed
         mock_query_job.result.return_value = []
+        mock_query_job.num_dml_affected_rows = 1
+
         mock_client.query.return_value = mock_query_job
         yield mock
 
@@ -98,14 +102,23 @@ def test_generate_embeddings_success(mock_bq):
     service = RAGIngestion()
     request = GenerateEmbeddingsRequest(gcs_uri="gs://test-bucket/processed/test.pdf")
 
+    # Mock the verify query explicitly since we changed the default mock behavior
+    mock_bq_client = mock_bq.return_value
+    mock_result = MagicMock()
+    mock_result.count = 1
+    mock_query_job = MagicMock()
+    mock_query_job.result.return_value = iter([mock_result])
+    mock_query_job.num_dml_affected_rows = 1
+    mock_bq_client.query.return_value = mock_query_job
+
     response = service.generate_embeddings(request)
 
     assert response.success is True
-    assert response.execution_status == "SUCCESS"
+    assert "SUCCESS" in response.execution_status
 
     mock_bq_client = mock_bq.return_value
-    mock_bq_client.query.assert_called_once()
-    args, kwargs = mock_bq_client.query.call_args
+    assert mock_bq_client.query.call_count == 2
+    args, kwargs = mock_bq_client.query.call_args_list[0]
     query_str = args[0]
 
     assert (


### PR DESCRIPTION
## Purpose
This PR modifies the GCS path folder structure for the Enterprise Knowledge Base pipeline. It changes the destination structure so that the project_name precedes the security_tier, keeping the remaining folder structure untouched.

## Important Changes
- Updated `dest_base` in `pipeline.py` to construct the path as `gs://kb-{domain}/{project_name}/{tier_label}/{uploader_email_prefix}/`.
- Synchronized expected GCS URIs across all associated integration and unit tests.
- Updated `routing_and_persistence.md` and `Design.md` to reflect the new structure.