### PR TITLE
feat(agent): Grant OWNER ACL to uploaders in GE ingestion plugin

### DIFF
--- a/agent/core_agent/plugins/user_uploads.py
+++ b/agent/core_agent/plugins/user_uploads.py
@@ -1,8 +1,10 @@
+import asyncio
 import copy
 from typing import Optional
 
 from google.adk.agents.invocation_context import InvocationContext
 from google.adk.plugins.base_plugin import BasePlugin
+from google.cloud import storage
 from google.genai import types
 from loguru import logger
 
@@ -123,6 +125,9 @@ class GeminiEnterpriseFileIngestionPlugin(BasePlugin):
             )
             if gcs_part:
                 result.append(gcs_part)
+                await self._grant_uploader_object_acl(
+                    gcs_part.file_data.file_uri, invocation_context.user_id
+                )
             return result
 
         except Exception as exc:
@@ -181,3 +186,39 @@ class GeminiEnterpriseFileIngestionPlugin(BasePlugin):
                 display_name=filename,
             )
         )
+
+    async def _grant_uploader_object_acl(
+        self, canonical_uri: str, user_email: str
+    ) -> None:
+        """Grants the uploading user OWNER-level ACL on their uploaded GCS object.
+
+        Uses Application Default Credentials (service account) to set per-object ACL,
+        giving the uploader storage.objectAdmin access over the specific file they uploaded.
+        Logs a warning without raising if the grant fails (e.g., uniform bucket-level access).
+
+        Args:
+            canonical_uri: str -> The canonical gs:// URI of the uploaded GCS object.
+            user_email: str -> The email of the user who performed the upload.
+
+        Returns:
+            None
+        """
+        try:
+            object_path = canonical_uri[len("gs://") :]
+            bucket_name, object_name = object_path.split("/", 1)
+            client = storage.Client()
+            blob = client.bucket(bucket_name).blob(object_name)
+
+            def _apply_acl() -> None:
+                blob.acl.reload()
+                blob.acl.user(user_email).grant_owner()
+                blob.acl.save()
+
+            await asyncio.to_thread(_apply_acl)
+            logger.info(
+                f"Granted OWNER ACL on '{canonical_uri}' for uploader: {user_email}"
+            )
+        except Exception as exc:
+            logger.warning(
+                f"Could not set uploader ACL on '{canonical_uri}' for '{user_email}': {exc}"
+            )

--- a/agent/tests/test_user_uploads.py
+++ b/agent/tests/test_user_uploads.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from google.genai import types
 
@@ -308,10 +308,78 @@ async def test_one_failed_part_does_not_prevent_other_parts_from_processing():
     ctx = _make_invocation_context(artifact_service=svc)
     msg = _make_user_message([failing_part, good_part])
 
-    result = await plugin.on_user_message_callback(
-        invocation_context=ctx, user_message=msg
-    )
+    with patch("agent.core_agent.plugins.user_uploads.storage.Client"):
+        result = await plugin.on_user_message_callback(
+            invocation_context=ctx, user_message=msg
+        )
 
     assert result is not None
     assert result.parts[0] is failing_part
     assert len(result.parts) == 3  # original failing + placeholder + file_data for good
+
+
+# ─── ACL Grant ────────────────────────────────────────────────────────────────
+
+
+async def test_grants_uploader_owner_acl_on_successful_upload():
+    """Should grant OWNER ACL on the uploaded GCS object using the uploader's email."""
+    plugin = GeminiEnterpriseFileIngestionPlugin()
+    inline_part = _make_inline_part(
+        display_name="report.pdf", mime_type="application/pdf"
+    )
+    ctx = _make_invocation_context(
+        artifact_version=_make_artifact_version("gs://landing-zone/report.pdf")
+    )
+    ctx.user_id = "uploader@example.com"
+    msg = _make_user_message([inline_part])
+
+    with patch("agent.core_agent.plugins.user_uploads.storage.Client") as mock_client:
+        mock_blob = MagicMock()
+        mock_client.return_value.bucket.return_value.blob.return_value = mock_blob
+
+        await plugin.on_user_message_callback(invocation_context=ctx, user_message=msg)
+
+    mock_client.return_value.bucket.assert_called_once_with("landing-zone")
+    mock_client.return_value.bucket.return_value.blob.assert_called_once_with(
+        "report.pdf"
+    )
+    mock_blob.acl.user.assert_called_once_with("uploader@example.com")
+    mock_blob.acl.user.return_value.grant_owner.assert_called_once()
+    mock_blob.acl.save.assert_called_once()
+
+
+async def test_acl_grant_failure_does_not_block_upload():
+    """Should complete the upload and return parts even when the ACL grant raises."""
+    plugin = GeminiEnterpriseFileIngestionPlugin()
+    inline_part = _make_inline_part(display_name="file.png")
+    ctx = _make_invocation_context(
+        artifact_version=_make_artifact_version("gs://landing-zone/file.png")
+    )
+    msg = _make_user_message([inline_part])
+
+    with patch("agent.core_agent.plugins.user_uploads.storage.Client") as mock_client:
+        mock_blob = MagicMock()
+        mock_blob.acl.save.side_effect = RuntimeError("UBLA enabled")
+        mock_client.return_value.bucket.return_value.blob.return_value = mock_blob
+
+        result = await plugin.on_user_message_callback(
+            invocation_context=ctx, user_message=msg
+        )
+
+    assert result is not None
+    assert len(result.parts) == 2  # placeholder + file_data still returned
+
+
+async def test_acl_not_attempted_when_no_gcs_uri():
+    """Should skip ACL grant entirely when the canonical URI is unavailable."""
+    plugin = GeminiEnterpriseFileIngestionPlugin()
+    inline_part = _make_inline_part(display_name="file.png")
+    ctx = _make_invocation_context(
+        artifact_version=_make_artifact_version(canonical_uri=None)
+    )
+    msg = _make_user_message([inline_part])
+
+    with patch("agent.core_agent.plugins.user_uploads.storage.Client") as mock_client:
+        await plugin.on_user_message_callback(invocation_context=ctx, user_message=msg)
+
+    mock_client.assert_not_called()

--- a/docs/AI-Agent-Development/10-User-Uploads-ACL.md
+++ b/docs/AI-Agent-Development/10-User-Uploads-ACL.md
@@ -1,4 +1,4 @@
-# User Uploads ACL Plugin
+# 10 - User Uploads ACL Plugin
 
 ## Overview
 The `GeminiEnterpriseFileIngestionPlugin` intercepts user-uploaded files from Gemini Enterprise, persists them to Google Cloud Storage (GCS), and replaces the binary payload with a GCS-backed reference. 

--- a/docs/modules/user_uploads_acl.md
+++ b/docs/modules/user_uploads_acl.md
@@ -1,0 +1,27 @@
+# User Uploads ACL Plugin
+
+## Overview
+The `GeminiEnterpriseFileIngestionPlugin` intercepts user-uploaded files from Gemini Enterprise, persists them to Google Cloud Storage (GCS), and replaces the binary payload with a GCS-backed reference. 
+
+To ensure users can manage their own uploads, the plugin automatically grants the uploader `OWNER` level access (similar to Storage Object Admin) to the specific GCS object they uploaded.
+
+## Architecture
+When a file is uploaded:
+1. The plugin saves the artifact using the `ArtifactService`.
+2. It retrieves the canonical `gs://` URI.
+3. It extracts the bucket and object name.
+4. It uses the GCS Python SDK (via Service Account credentials) to update the object's ACL:
+   ```python
+   blob.acl.user(user_email).grant_owner()
+   blob.acl.save()
+   ```
+
+## Security Considerations
+- **Least Privilege**: The ACL is applied only to the specific object uploaded by the user, not the entire bucket.
+- **Identity Trust**: The `user_email` is retrieved from the `InvocationContext`, which is populated by the ADK framework from the authenticated user's session.
+- **UBLA Compatibility**: If the target bucket has **Uniform Bucket-Level Access (UBLA)** enabled, ACL operations will fail. The plugin logs this as a warning but does not block the upload, as the file is still successfully persisted and accessible to the agent.
+
+## Implementation Details
+- **Location**: `agent/core_agent/plugins/user_uploads.py`
+- **Method**: `_grant_uploader_object_acl`
+- **Error Handling**: Uses `asyncio.to_thread` for the synchronous GCS call and catches all exceptions to prevent ingestion failures if ACL granting fails.

--- a/terraform/ai_agent_resources/main.tf
+++ b/terraform/ai_agent_resources/main.tf
@@ -66,7 +66,7 @@ resource "google_storage_bucket" "artifact_bucket" {
   project                     = var.project_id
   name                        = var.artifact_bucket_name
   location                    = var.main_region
-  uniform_bucket_level_access = true
+  uniform_bucket_level_access = false
   force_destroy               = false
 
   versioning {


### PR DESCRIPTION
## Summary
This PR implements per-object OWNER ACL grants for users who upload files through the Gemini Enterprise (GE) file ingestion plugin. This ensures that users have full administrative control over the artifacts they upload to the agent's landing zone.

## Changes
- **Plugin Logic**: Added `_grant_uploader_object_acl` to `GeminiEnterpriseFileIngestionPlugin` in `agent/core_agent/plugins/user_uploads.py`.
- **Infrastructure**: Modified `terraform/ai_agent_resources/main.tf` to disable `uniform_bucket_level_access` on the artifact bucket, which is a prerequisite for per-object ACLs.
- **Tests**: Added comprehensive unit tests in `agent/tests/test_user_uploads.py` covering success, failure, and edge cases (like missing GCS URIs).
- **Documentation**: Created `docs/modules/user_uploads_acl.md` detailing the architecture and security considerations.

## Verification
- Ran `uv run pytest agent/tests/test_user_uploads.py` (16 passed).
- Verified linting with `make run-agent-precommit`.
- Conducted cybersecurity audit (0 High/Urgent threats).