### PR TITLE
EKB Pipeline / Fix - decouple internal results from async tracking response

### DIFF
--- a/agent/skills/kb-file-ingestion/SKILL.md
+++ b/agent/skills/kb-file-ingestion/SKILL.md
@@ -42,23 +42,29 @@ Maintain this state throughout the interaction:
 ### Step 2: Information Gathering & Validation
 To minimize turns, **ALWAYS** ask for all necessary information in a single bulleted message immediately after Step 1:
 
-"First, provide the following information before storing it into the knowledge base:
-- **project the file belongs to**
+"Before storing the file, please provide me the following information:
+- **project the file belongs to**:
 - **domain**: (Options: `IT, Finance, HR, Sales, Executives, Legal, Operations`)
-- **trust level**: (Options: `Published`, `WIP`, `Archived`)
-- **pii?**: Does this document contain any Personally Identifiable Information?"
+- **trust-level**: (Options: 
+    - `Published`: Document is currently valid and verified.
+    - `WIP`: Work in progress, potentially incomplete.
+    - `Archived`: No longer valid, kept for reference only.)
+- **PII Status**: Does this document contain any Personally Identifiable Information?"
 
 **Once the user provides the information, perform the following in sequence:**
 
 1.  **Semantic Project Validation**: Use `ekb_semantic_search(query='<user_input_project_name>')`.
     - If a high-confidence match exists, proceed with that `project_id`.
     - If ambiguous, ask: "I found existing projects that might match: [List]. Is it one of these?"
-2.  **Deduplication Check**: If the project exists, check for duplicate filenames:
+2.  **Deduplication Check**: If the project exists, check for duplicate filenames and retrieve their existing metadata:
     ```sql
-    SELECT filename FROM `knowledge_base.documents_metadata` 
+    SELECT filename, domain, classification_tier 
+    FROM `knowledge_base.documents_metadata` 
     WHERE project_id = '<confirmed_project>' AND lower(filename) = lower('<uploaded_filename>')
+      AND latest = TRUE
     ```
     - If found, ask: "A version of '<filename>' already exists. Should I replace it or would you like to rename this file?"
+    - **MANDATORY**: If the user chooses to **REPLACE** the file, you MUST reuse the `domain` and `classification_tier` retrieved from the existing record for the new ingestion.
 3.  **Final Summary**: Confirm the final metadata values with the user before proceeding to Step 3.
 
 ### Step 3: Relocation & Stamping

--- a/agent/skills/kb-file-ingestion/SKILL.md
+++ b/agent/skills/kb-file-ingestion/SKILL.md
@@ -56,16 +56,16 @@ Maintain this state throughout the interaction:
     - **Note**: Skip this check if the user is creating a completely new project.
 
 ### Step 3: Metadata Collection
-To avoid a tedious multi-turn interaction, **ALWAYS** ask for the information at once using the following structure:
+To avoid a tedious multi-turn interaction, **ALWAYS** ask for the information at once using the following bulleted structure:
 
-"Before storing the file, please provide me the following information:
+"First, provide the following information before storing it into the knowledge base:
 - **project the file belongs to**: (Confirming '[Project Name]')
 - **domain**: (Options: `IT, Finance, HR, Sales, Executives, Legal, Operations`)
-- **trust-level**: (Options: 
+- **trust level**: (Options: 
     - `Published`: Document is currently valid and verified.
     - `WIP`: Work in progress, potentially incomplete.
     - `Archived`: No longer valid, kept for reference only.)
-- **PII Status**: Does this document contain any Personally Identifiable Information?"
+- **pii?**: Does this document contain any Personally Identifiable Information?"
 
 ### Step 4: Relocation & Stamping
 1.  **Move File**: Use `upload_object` (from GCS MCP) to copy the file using these parameters:

--- a/agent/skills/kb-file-ingestion/SKILL.md
+++ b/agent/skills/kb-file-ingestion/SKILL.md
@@ -19,10 +19,9 @@ or similar requests.
 ## Progress Tracker
 Maintain this state throughout the interaction:
 - [ ] Step 1: Identify and verify session artifact
-- [ ] Step 2: Validate project and filename (Deduplication)
-- [ ] Step 3: Collect metadata (Domain, Trust, PII)
-- [ ] Step 4: Relocate file and stamp metadata
-- [ ] Step 5: Trigger EKB Pipeline
+- [ ] Step 2: Collect metadata and validate project (Deduplication)
+- [ ] Step 3: Relocate file and stamp metadata
+- [ ] Step 4: Trigger EKB Pipeline
 
 ## Gotchas
 - **GCS URIs**: The agent landing zone is always `gs://ai_agent_landing_zone/`. 
@@ -40,34 +39,29 @@ Maintain this state throughout the interaction:
     - **Multi-file**: If multiple PDF files exist, ask: "I see several PDFs ([List]). Which one should I ingest?"
     - **Missing**: If no PDF file is found, ask: "Please upload the PDF document you'd like to add to the knowledge base."
 
-### Step 2: Project Validation & Deduplication
-1.  **Project Identification**: Ask the user: "Which project does this document belong to?"
-2.  **Semantic Validation**: Use `ekb_semantic_search(query='<user_input_project_name>')` to find similar projects in the knowledge base.
-3.  **Conflict Resolution**:
-    - If similar projects are found, present the list and ask: "I found existing projects that might match: [List]. Is it one of these, or should I create a new project entry for '[User Input]'?"
-    - If no similar projects are found, proceed with the user's input.
-4.  **Conditional Filename Check**: **ONLY** if an existing project was confirmed in the previous step, check if a file with the same name already exists:
-    ```sql
-    SELECT filename 
-    FROM `knowledge_base.documents_metadata` 
-    WHERE project_id = '<confirmed_project>' AND lower(filename) = lower('<uploaded_filename>')
-    ```
-    - If it exists, ask: "A version of '<filename>' already exists in project '<project>'. Should I replace it or would you like to rename this file?"
-    - **Note**: Skip this check if the user is creating a completely new project.
-
-### Step 3: Metadata Collection
-To avoid a tedious multi-turn interaction, **ALWAYS** ask for the information at once using the following bulleted structure:
+### Step 2: Information Gathering & Validation
+To minimize turns, **ALWAYS** ask for all necessary information in a single bulleted message immediately after Step 1:
 
 "First, provide the following information before storing it into the knowledge base:
-- **project the file belongs to**: (Confirming '[Project Name]')
+- **project the file belongs to**
 - **domain**: (Options: `IT, Finance, HR, Sales, Executives, Legal, Operations`)
-- **trust level**: (Options: 
-    - `Published`: Document is currently valid and verified.
-    - `WIP`: Work in progress, potentially incomplete.
-    - `Archived`: No longer valid, kept for reference only.)
+- **trust level**: (Options: `Published`, `WIP`, `Archived`)
 - **pii?**: Does this document contain any Personally Identifiable Information?"
 
-### Step 4: Relocation & Stamping
+**Once the user provides the information, perform the following in sequence:**
+
+1.  **Semantic Project Validation**: Use `ekb_semantic_search(query='<user_input_project_name>')`.
+    - If a high-confidence match exists, proceed with that `project_id`.
+    - If ambiguous, ask: "I found existing projects that might match: [List]. Is it one of these?"
+2.  **Deduplication Check**: If the project exists, check for duplicate filenames:
+    ```sql
+    SELECT filename FROM `knowledge_base.documents_metadata` 
+    WHERE project_id = '<confirmed_project>' AND lower(filename) = lower('<uploaded_filename>')
+    ```
+    - If found, ask: "A version of '<filename>' already exists. Should I replace it or would you like to rename this file?"
+3.  **Final Summary**: Confirm the final metadata values with the user before proceeding to Step 3.
+
+### Step 3: Relocation & Stamping
 1.  **Move File**: Use `upload_object` (from GCS MCP) to copy the file using these parameters:
     - `source_gcs_uri`: The URI identified in Step 1.
     - `destination_bucket`: "ag-core-dev-fdx7-kb-landing-zone"
@@ -84,8 +78,8 @@ To avoid a tedious multi-turn interaction, **ALWAYS** ask for the information at
     }
     ```
 
-### Step 5: Trigger Pipeline
-1.  Call `trigger_ekb_pipeline(gcs_uri='<destination_uri_returned_in_Step_4>')`.
+### Step 4: Trigger Pipeline
+1.  Call `trigger_ekb_pipeline(gcs_uri='<destination_uri_returned_in_Step_3>')`.
     - **Note**: This MUST be exactly the same URI returned by the `upload_object` tool.
 2.  **Final Confirmation**: Provide the user with a summary using this template:
     ```markdown

--- a/pipelines/enterprise_knowledge_base/app/orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/app/orchestrator.py
@@ -7,7 +7,7 @@ from .rag_ingestion import (
     IngestDocumentRequest,
     RAGIngestion,
 )
-from .schemas import OrchestratorRunRequest, OrchestratorRunResponse
+from .schemas import OrchestratorRunRequest, PipelineResult
 
 
 class KBIngestionPipeline:
@@ -27,14 +27,14 @@ class KBIngestionPipeline:
         self.classification_pipeline = ClassificationPipeline()
         self.rag_pipeline = RAGIngestion()
 
-    def run(self, request: OrchestratorRunRequest) -> OrchestratorRunResponse:
+    def run(self, request: OrchestratorRunRequest) -> PipelineResult:
         """Orchestrates the entire ingestion process end-to-end.
 
         Args:
             request: OrchestratorRunRequest -> The request containing the landing URI.
 
         Returns:
-            OrchestratorRunResponse -> Results of the pipeline execution.
+            PipelineResult -> Results of the pipeline execution.
         """
         logger.info(f"Triggering KB Ingestion Pipeline for: {request.gcs_uri}")
 
@@ -66,7 +66,7 @@ class KBIngestionPipeline:
             class_resp.final_security_tier, "unknown"
         )
 
-        return OrchestratorRunResponse(
+        return PipelineResult(
             gcs_uri=class_resp.final_original_uri,
             chunks_generated=ingest_resp.chunk_count,
             final_domain=class_resp.final_domain,

--- a/pipelines/enterprise_knowledge_base/app/schemas.py
+++ b/pipelines/enterprise_knowledge_base/app/schemas.py
@@ -29,6 +29,15 @@ class OrchestratorRunRequest(BaseModel):
         return self.gcs_uri.split("/")[-1]
 
 
+class PipelineResult(BaseModel):
+    """Schema for the internal results of the pipeline execution."""
+
+    gcs_uri: Annotated[str, Field(description="The final GCS URI in the domain bucket")]
+    chunks_generated: Annotated[int, Field(description="Number of chunks created")]
+    final_domain: Annotated[str, Field(description="The determined business domain")]
+    security_tier: Annotated[str, Field(description="The security tier label")]
+
+
 class OrchestratorRunResponse(BaseModel):
     """Response schema for the initial async trigger."""
 

--- a/pipelines/enterprise_knowledge_base/tests/test_orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_orchestrator.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+from pipelines.enterprise_knowledge_base.app.orchestrator import KBIngestionPipeline
+from pipelines.enterprise_knowledge_base.app.schemas import (
+    OrchestratorRunRequest,
+    PipelineResult,
+)
+
+
+def test_orchestrator_run_returns_pipeline_result():
+    """
+    Regression test: Ensure the orchestrator returns PipelineResult, not OrchestratorRunResponse.
+    This prevents validation errors in the background task that manages job status updates.
+    """
+    with (
+        patch(
+            "pipelines.enterprise_knowledge_base.app.orchestrator.ClassificationPipeline"
+        ),
+        patch("pipelines.enterprise_knowledge_base.app.orchestrator.RAGIngestion"),
+    ):
+        pipeline = KBIngestionPipeline("test-project")
+
+        # Mock internal pipeline responses
+        mock_class_resp = MagicMock()
+        mock_class_resp.final_original_uri = "gs://kb-it/project/file.pdf"
+        mock_class_resp.final_domain = "it"
+        mock_class_resp.final_security_tier = 1  # Tier 1 -> public
+        pipeline.classification_pipeline.run.return_value = mock_class_resp
+
+        mock_rag_resp = MagicMock()
+        mock_rag_resp.chunk_count = 42
+        mock_rag_resp.execution_status = "SUCCESS"
+        pipeline.rag_pipeline.run.return_value = mock_rag_resp
+
+        request = OrchestratorRunRequest(gcs_uri="gs://landing/file.pdf")
+        result = pipeline.run(request)
+
+        # Validation
+        assert isinstance(result, PipelineResult), (
+            "Orchestrator must return PipelineResult"
+        )
+        assert result.gcs_uri == "gs://kb-it/project/file.pdf"
+        assert result.chunks_generated == 42
+        assert result.final_domain == "it"
+        assert result.security_tier == "public"
+
+        # Ensure it does not contain the OrchestratorRunResponse fields which would fail validation
+        # if they were required but missing (the root cause of the bug).
+        assert not hasattr(result, "job_id")
+        assert not hasattr(result, "status")


### PR DESCRIPTION
## Problem
The asynchronous refactor introduced a ValidationError during the final step of the EKB pipeline. This happened because OrchestratorRunResponse was updated to require job-tracking fields (job_id, status, message) for the initial async response, but the internal orchestrator was still using this model to return processing results (gcs_uri, chunks, etc.), which do not have those fields.

## Solution
- Created a new PipelineResult schema for internal ingestion results.
- Refactored KBIngestionPipeline.run to return PipelineResult instead of the external OrchestratorRunResponse.
- This separation ensures that internal pipeline logic remains decoupled from the async job tracking infrastructure.

## Verification
- Passed uv run pytest tests/test_main.py in the pipeline directory.