### PR TITLE
EKB Pipeline / Resolve Ingestion Callback Timeout and Event Loop Blocking

### DIFF
--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -26,10 +26,12 @@ async def sync_ingestion_status(
     """
     pending_jobs = list(callback_context.state.get(PENDING_INGESTIONS_KEY, []))
     if not pending_jobs:
-        logger.debug("No pending ingestion jobs to sync.")
+        logger.trace("No pending ingestion jobs in session state.")
         return None
 
-    logger.info(f"Syncing status for {len(pending_jobs)} pending ingestion job(s).")
+    logger.info(
+        f"Syncing status for {len(pending_jobs)} pending ingestion job(s): {[j.get('filename') for j in pending_jobs]}"
+    )
 
     still_pending = []
     completed_updates = []
@@ -105,9 +107,10 @@ async def sync_ingestion_status(
         # ADK 2.0 uses session.events for history
         callback_context.session.events.append(new_event)
 
-        logger.debug(
-            f"History updated with {len(completed_updates)} background task results."
+        logger.info(
+            f"Proactive history update successful for {len(completed_updates)} jobs."
         )
 
     # Always return None to allow the agent to run and see the new history
+    logger.trace("Ingestion sync cycle completed.")
     return None

--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -1,5 +1,6 @@
 import httpx
-from google.adk.agents.context import Context
+from google.adk.agents.callback_context import CallbackContext
+from google.adk.events.event import Event
 from google.genai import types
 from loguru import logger
 
@@ -7,24 +8,26 @@ from ..config import AGENT_CONFIG
 from ..security import get_id_token
 from ..tools.kb_tools import PENDING_INGESTIONS_KEY
 
+from typing import Optional
+
 
 async def sync_ingestion_status(
-    callback_context: Context,
-) -> None:
+    callback_context: CallbackContext,
+) -> Optional[types.Content]:
     """
-    Proactively checks the status of pending ingestion jobs and injects updates into history.
+    Proactively checks the status of pending ingestion jobs and injects updates into session history.
     This enables proactive notifications in Gemini Enterprise by 'noticing' finished tasks.
 
     Args:
-        callback_context: Context -> The ADK callback context with state and history access.
+        callback_context: CallbackContext -> The ADK callback context.
 
     Returns:
-        None
+        Optional[types.Content] -> None, to allow the agent to continue its execution.
     """
     pending_jobs = list(callback_context.state.get(PENDING_INGESTIONS_KEY, []))
     if not pending_jobs:
         logger.debug("No pending ingestion jobs to sync.")
-        return
+        return None
 
     logger.info(f"Syncing status for {len(pending_jobs)} pending ingestion job(s).")
 
@@ -34,7 +37,7 @@ async def sync_ingestion_status(
     id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
     if not id_token:
         logger.warning("Skipping status sync: Could not obtain ID token.")
-        return
+        return None
 
     headers = {"Authorization": f"Bearer {id_token}"}
 
@@ -72,7 +75,7 @@ async def sync_ingestion_status(
     # Update session state
     callback_context.state[PENDING_INGESTIONS_KEY] = still_pending
 
-    # If any jobs finished, inject a System Message into the history
+    # If any jobs finished, inject an Event into the session history
     if completed_updates:
         logger.info(
             f"Injecting {len(completed_updates)} completion updates into history."
@@ -91,7 +94,20 @@ async def sync_ingestion_status(
                     f"Security Tier: {update['details'].get('security_tier')}\n"
                 )
 
-        # Append as a system message to the history so Gemini 'sees' it before generating its response
-        callback_context.history.append(
-            types.Content(role="user", parts=[types.Part(text=update_text)])
+        # Create a new Event and append to history
+        # We use author='user' with a SYSTEM prefix so the agent treats it as context
+        new_event = Event(
+            invocation_id=callback_context.invocation_id,
+            author="user",
+            content=types.Content(role="user", parts=[types.Part(text=update_text)]),
         )
+
+        # ADK 2.0 uses session.events for history
+        callback_context.session.events.append(new_event)
+
+        logger.debug(
+            f"History updated with {len(completed_updates)} background task results."
+        )
+
+    # Always return None to allow the agent to run and see the new history
+    return None

--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -50,11 +50,14 @@ async def sync_ingestion_status(
 
             try:
                 url = f"{AGENT_CONFIG.EKB_PIPELINE_URL.strip('/')}/status/{job_id}"
+                logger.debug(f"Checking status for job {job_id} at {url}")
                 response = await client.get(url, headers=headers, timeout=5.0)
 
+                logger.debug(f"Status for job {job_id}: {response.status_code}")
                 if response.status_code == 200:
                     data = response.json()
                     status = data.get("status")
+                    logger.debug(f"Status for job {job_id}: {status}")
 
                     if status in ["success", "error"]:
                         logger.info(
@@ -63,7 +66,13 @@ async def sync_ingestion_status(
                         completed_updates.append(
                             {"filename": filename, "status": status, "details": data}
                         )
+                        logger.debug(
+                            f"Job {job_id} added to completed_updates. Current count: {len(completed_updates)}"
+                        )
                     else:
+                        logger.debug(
+                            f"Job {job_id} still in progress (status: {status})."
+                        )
                         still_pending.append(job)
                 else:
                     logger.warning(
@@ -86,6 +95,9 @@ async def sync_ingestion_status(
 
     # Update session state
     callback_context.state[PENDING_INGESTIONS_KEY] = still_pending
+    logger.debug(
+        f"Updated session state: {len(still_pending)} jobs remaining in pending list."
+    )
 
     # If any jobs finished, inject an Event into the session history
     if completed_updates:

--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -27,7 +27,7 @@ async def sync_ingestion_status(
     pending_jobs = list(callback_context.state.get(PENDING_INGESTIONS_KEY, []))
     if not pending_jobs:
         logger.debug("No pending ingestion jobs in session state.")
-        return None
+        return
 
     logger.info(
         f"Syncing status for {len(pending_jobs)} pending ingestion job(s): {[j.get('filename') for j in pending_jobs]}"
@@ -39,7 +39,7 @@ async def sync_ingestion_status(
     id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
     if not id_token:
         logger.warning("Skipping status sync: Could not obtain ID token.")
-        return None
+        return
 
     headers = {"Authorization": f"Bearer {id_token}"}
 
@@ -135,4 +135,4 @@ async def sync_ingestion_status(
 
     # Always return None to allow the agent to run and see the new history
     logger.debug("Ingestion sync cycle completed.")
-    return None
+    return

--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -70,8 +70,18 @@ async def sync_ingestion_status(
                         f"Failed to check status for {job_id}: {response.status_code}"
                     )
                     still_pending.append(job)
+            except httpx.TimeoutException:
+                logger.warning(f"Timeout syncing status for job {job_id} (5s).")
+                still_pending.append(job)
+            except httpx.RequestError as exc:
+                logger.error(
+                    f"Network error syncing status for job {job_id} at {exc.request.url}: {exc}"
+                )
+                still_pending.append(job)
             except Exception as e:
-                logger.error(f"Error syncing status for job {job_id}: {e}")
+                logger.error(
+                    f"Unexpected error syncing status for job {job_id}: {type(e).__name__} - {e}"
+                )
                 still_pending.append(job)
 
     # Update session state

--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -51,7 +51,7 @@ async def sync_ingestion_status(
             try:
                 url = f"{AGENT_CONFIG.EKB_PIPELINE_URL.strip('/')}/status/{job_id}"
                 logger.debug(f"Checking status for job {job_id} at {url}")
-                response = await client.get(url, headers=headers, timeout=5.0)
+                response = await client.get(url, headers=headers, timeout=10.0)
 
                 logger.debug(f"Status for job {job_id}: {response.status_code}")
                 if response.status_code == 200:

--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -26,7 +26,7 @@ async def sync_ingestion_status(
     """
     pending_jobs = list(callback_context.state.get(PENDING_INGESTIONS_KEY, []))
     if not pending_jobs:
-        logger.trace("No pending ingestion jobs in session state.")
+        logger.debug("No pending ingestion jobs in session state.")
         return None
 
     logger.info(
@@ -112,5 +112,5 @@ async def sync_ingestion_status(
         )
 
     # Always return None to allow the agent to run and see the new history
-    logger.trace("Ingestion sync cycle completed.")
+    logger.debug("Ingestion sync cycle completed.")
     return None

--- a/agent/core_agent/tools/kb_tools.py
+++ b/agent/core_agent/tools/kb_tools.py
@@ -103,7 +103,9 @@ class TriggerEKBPipelineTool(BaseTool):
                 pending.append({"job_id": job_id, "filename": filename})
                 tool_context.state[PENDING_INGESTIONS_KEY] = pending
 
-                logger.info(f"Ingestion job {job_id} started for {filename}")
+                logger.info(
+                    f"Stored pending ingestion in state: {filename} ({job_id}). Total pending: {len(pending)}"
+                )
 
                 return TriggerEKBPipelineResponse(
                     execution_status="success",

--- a/agent/core_agent/tools/kb_tools.py
+++ b/agent/core_agent/tools/kb_tools.py
@@ -185,11 +185,19 @@ class CheckIngestionStatusTool(BaseTool):
             headers = {"Authorization": f"Bearer {id_token}"}
             async with httpx.AsyncClient() as client:
                 response = await client.get(url, headers=headers, timeout=10.0)
+                logger.debug(
+                    f"Response status from EKB for {request.job_id}: {response.status_code}"
+                )
                 response.raise_for_status()
                 data = response.json()
+                logger.info(
+                    f"Retrieved status for {request.job_id}: {data.get('status')}"
+                )
                 return CheckIngestionStatusResponse(**data).model_dump()
         except Exception as e:
-            logger.error(f"Error checking ingestion status: {e}")
+            logger.error(
+                f"Error checking ingestion status for job {args.get('job_id')}: {e}"
+            )
             return CheckIngestionStatusResponse(
                 job_id=args.get("job_id", "N/A"),
                 status="error",

--- a/agent/skills/kb-file-ingestion/SKILL.md
+++ b/agent/skills/kb-file-ingestion/SKILL.md
@@ -46,10 +46,10 @@ To minimize turns, **ALWAYS** ask for all necessary information in a single bull
 - **project the file belongs to**:
 - **domain**: (Options: `IT, Finance, HR, Sales, Executives, Legal, Operations`)
 - **trust-level**: (Options: 
-    - `Published`: Document is currently valid and verified.
-    - `WIP`: Work in progress, potentially incomplete.
-    - `Archived`: No longer valid, kept for reference only.)
-- **PII Status**: Does this document contain any Personally Identifiable Information?"
+    - `Published`: Verified, official document that is currently valid and ready for company-wide consumption.
+    - `WIP` (Work In Progress): Draft or evolving document that is still being refined; use this for active projects.
+    - `Archived`: Historical reference that is no longer active or valid, but should be kept for context or audit purposes.)
+- **PII Status**: Does this document contain any Personally Identifiable Information (Names, emails, IDs)?"
 
 **Once the user provides the information, perform the following in sequence:**
 

--- a/docs/AI-Agent-Development/11-KB-Ingestion-Pipeline.md
+++ b/docs/AI-Agent-Development/11-KB-Ingestion-Pipeline.md
@@ -32,3 +32,13 @@ The module relies on the following environment variables:
 3. Skill moves the file from `ai_agent_landing_zone` to `kb-landing-zone`.
 4. Skill stamps metadata on the destination object.
 5. Tool triggers the `/ingest` endpoint on the EKB Pipeline.
+
+## Proactive Notification System
+The agent core includes a **`sync_ingestion_status`** callback that enhances the user experience by providing real-time updates on background jobs.
+
+- **Hook**: `before_agent_callback`.
+- **Logic**:
+    - Checks the session state for pending `job_id`s.
+    - Synchronizes status with the EKB Pipeline `/status` endpoint.
+    - If a job is finished, it injects a **System Update** event into the conversation history using the ADK 2.0 `session.events` pattern.
+- **Benefit**: The agent "notices" when a document is ready for use right before responding to the user, even if the user didn't explicitly ask for a status update.

--- a/pipelines/enterprise_knowledge_base/README.md
+++ b/pipelines/enterprise_knowledge_base/README.md
@@ -80,7 +80,7 @@ The following variables are required for the Cloud Run deployment (configured vi
 ## API Reference
 
 ### 1. Trigger Ingestion (POST `/ingest`)
-Triggers the asynchronous pipeline. Returns a `job_id` immediately.
+Triggers the asynchronous pipeline. This endpoint is non-blocking; the heavy orchestration logic (classification and vectorization) is executed in a background thread pool to ensure the API remains responsive. Returns a `job_id` immediately.
 
 **Request Body:**
 ```json
@@ -99,7 +99,7 @@ Triggers the asynchronous pipeline. Returns a `job_id` immediately.
 ```
 
 ### 2. Check Status (GET `/status/{job_id}`)
-Returns the current state and results of a job.
+Returns the current state and results of a job. This endpoint is used by the AI Agent's **Proactive Notification System** to monitor progress and inform the user upon completion.
 
 **Response (Success):**
 ```json

--- a/pipelines/enterprise_knowledge_base/app/main.py
+++ b/pipelines/enterprise_knowledge_base/app/main.py
@@ -20,7 +20,7 @@ app = FastAPI(
 job_service = JobService()
 
 
-def run_pipeline_task(job_id: str, request: OrchestratorRunRequest):
+def run_pipeline_task(job_id: str, request: OrchestratorRunRequest) -> None:
     """
     Background task to execute the sequential EKB pipeline (Classification -> RAG).
     Updates the BigQuery job status upon completion or failure.

--- a/pipelines/enterprise_knowledge_base/app/main.py
+++ b/pipelines/enterprise_knowledge_base/app/main.py
@@ -20,7 +20,7 @@ app = FastAPI(
 job_service = JobService()
 
 
-async def run_pipeline_task(job_id: str, request: OrchestratorRunRequest):
+def run_pipeline_task(job_id: str, request: OrchestratorRunRequest):
     """
     Background task to execute the sequential EKB pipeline (Classification -> RAG).
     Updates the BigQuery job status upon completion or failure.


### PR DESCRIPTION
### Problem
The AI agent was experiencing `TimeoutException (5s)` during the `sync_ingestion_status` callback while a document ingestion was in progress. Detailed investigation revealed that the `pipelines/enterprise_knowledge_base` service was blocking its own event loop. This occurred because the `/ingest` endpoint was calling the synchronous `pipeline.run()` method within an `async def` wrapper, which 'stalled' the entire FastAPI process, preventing it from responding to `/status` requests from the agent.

Additionally, the agent's callback was failing with `AttributeError` when attempting to access a non-existent `.history` attribute, which was replaced by the ADK 2.0-native `session.events` pattern.

### Fix
1.  **EKB Service (Blocking Fix)**: Refactored `run_pipeline_task` in `pipelines/enterprise_knowledge_base/app/main.py` from `async def` to `def`. This ensures FastAPI executes the heavy ingestion pipeline in a separate thread pool, keeping the main event loop responsive for status checks.
2.  **Agent Callback (ADK 2.0 Alignment)**: Migrated the ingestion status sync logic to use the `callback_context.session.events.append()` pattern.
3.  **Resilience**: Increased the callback HTTP timeout from 5s to 10s to accommodate potential service cold starts.
4.  **Logging**: Enhanced logging in both the agent and the pipeline service for better observability of background job states.
5.  **Documentation**: Updated `kb-file-ingestion` skill with clearer trust-level definitions (`Published`, `WIP`, `Archived`).

### Verification
- [x] Callback logic verified to handle `session.events`.
- [x] EKB pipeline unblocked (verified via architecture review of FastAPI threading behavior).
- [x] Skill documentation updated.