### PR TITLE
Enterprise Knowledge Base / Ingestion Pipeline -Prevent SSLEOFError by using Singleton GCP Clients in EKB Pipeline

### DIFF
--- a/docs/Data-Pipelines/Enterprise-Knowledge-Base/connection_pooling_and_reliability.md
+++ b/docs/Data-Pipelines/Enterprise-Knowledge-Base/connection_pooling_and_reliability.md
@@ -1,0 +1,49 @@
+# Connection Pooling and Pipeline Reliability
+
+## Overview
+The Enterprise Knowledge Base (EKB) ingestion pipeline processes documents asynchronously using FastAPI's `BackgroundTasks` deployed on Cloud Run. Under high-concurrency loads (e.g., uploading 10+ files simultaneously), the pipeline experienced intermittent network failures, most notably `SSLEOFError(8, 'EOF occurred in violation of protocol')` when interacting with Google Cloud Storage (GCS) and BigQuery.
+
+This document outlines the root cause of these network failures and details the architectural pattern implemented to guarantee pipeline reliability.
+
+## The Problem: Socket and TLS Exhaustion
+Initially, the orchestrator (`KBIngestionPipeline`) and its underlying domain services (`GCSService`, `BQService`, `RAGIngestion`, etc.) were instantiated dynamically for every incoming request. Within the `__init__` method of these services, a new Google Cloud SDK Client was created:
+
+```python
+# Anti-pattern: Bypassing Connection Pooling
+class BQService:
+    def __init__(self):
+        self.client = bigquery.Client(project=EKB_CONFIG.PROJECT_ID)
+```
+
+### Why this fails under load:
+1. **Connection Pool Bypass:** Google Cloud SDKs use the `requests` library (and `urllib3` under the hood) to maintain a thread-safe HTTP connection pool. This pool is tied to the lifecycle of the `Client` object.
+2. **TLS Handshake Overhead:** By creating a brand-new `Client` for every uploaded file, the application forced the OS to establish a new TCP connection and perform a full TLS handshake for every single API call.
+3. **Socket Starvation:** When multiple background tasks ran concurrently, the rapid creation of un-pooled connections exhausted the available ephemeral ports and triggered rate-limiting/connection drops from the GCP load balancers, resulting in the `SSLEOFError`.
+
+## The Solution: Class Attribute Singletons
+To ensure the underlying `urllib3` connection pool is securely shared across all concurrent threads, the architecture was refactored to use a strict **Module-Level Singleton / Class Attribute Pattern**.
+
+```python
+# Best Practice: Shared Connection Pooling
+from google.cloud import bigquery
+
+# 1. Instantiate the client globally at the module level
+bq_client = bigquery.Client(project=EKB_CONFIG.PROJECT_ID)
+
+class BQService:
+    # 2. Assign the global client as a Class Attribute
+    client = bq_client
+
+    def __init__(self):
+        # No client instantiation here
+        self.dataset_id = EKB_CONFIG.BQ_DATASET
+```
+
+### Why this approach guarantees reliability:
+1. **TCP Connection Reuse:** Because the `bq_client` is instantiated at the module level when the app starts, all instances of `BQService` share the exact same memory pointer to the client. This means all concurrent FastAPI background tasks natively share the same TCP connections to GCP, eliminating connection setup latency and socket exhaustion.
+2. **Memory Efficiency:** Storing the client as a class attribute rather than an instance attribute saves memory. The client object exists only once in the class definition, rather than being copied into the `__dict__` of every instantiated object.
+3. **High Testability:** The class attribute pattern allows for seamless dependency injection and mocking in unit tests (`@patch.object(BQService, 'client')`) without the boilerplate of custom `__init__` assignment.
+4. **Pythonic Resolution:** Python's attribute resolution order automatically falls back to class attributes when `self.client` is accessed, meaning the core logic of the class requires zero modification.
+
+## Orchestrator Singleton
+To further minimize object allocation overhead, the orchestrator itself (`KBIngestionPipeline`) is instantiated as a module-level singleton in `app/main.py`. The FastAPI router reuses this single, stateless instance to invoke the `run()` method for all incoming documents, ensuring a completely unbottlenecked, highly concurrent ingestion workflow.

--- a/pipelines/enterprise_knowledge_base/app/document_classification/bq_service/service.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/bq_service/service.py
@@ -10,11 +10,17 @@ from .schemas import (
 )
 
 
+# Global client to share connection pool across multiple requests
+bq_client = bigquery.Client(project=EKB_CONFIG.PROJECT_ID)
+
+
 class BQService:
     """Service class for BigQuery operations: metadata persistence and queries.
 
     Handles metadata insertion using Load Jobs to avoid streaming buffer limitations.
     """
+
+    client = bq_client
 
     SCHEMA = [
         bigquery.SchemaField("document_id", "STRING", mode="REQUIRED"),
@@ -38,7 +44,6 @@ class BQService:
         Returns:
             None
         """
-        self.client = bigquery.Client(project=EKB_CONFIG.PROJECT_ID)
         self.dataset_id = EKB_CONFIG.BQ_DATASET
         self.table_id = EKB_CONFIG.BQ_TABLE
 

--- a/pipelines/enterprise_knowledge_base/app/document_classification/dlp_service/service.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/dlp_service/service.py
@@ -5,12 +5,18 @@ from loguru import logger
 from ..config import EKB_CONFIG
 
 
+# Global client to share connection pool across multiple requests
+dlp_client = dlp_v2.DlpServiceClient()
+
+
 class DLPService:
     """Service class to handle Cloud DLP operations: scanning and de-identification.
 
     This service is responsible for 'Phase 1' of the classification pipeline,
     identifying high-risk data (Tiers 4 and 5) and polling for results.
     """
+
+    client = dlp_client
 
     def __init__(self, project_id: str = EKB_CONFIG.PROJECT_ID) -> None:
         """Initializes the DLP client using Application Default Credentials (ADC).
@@ -21,7 +27,6 @@ class DLPService:
         Returns:
             None
         """
-        self.client = dlp_v2.DlpServiceClient()
         self.project_id = project_id
         self.parent = f"projects/{project_id}/locations/global"
 

--- a/pipelines/enterprise_knowledge_base/app/document_classification/gcs_service/service.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/gcs_service/service.py
@@ -8,6 +8,10 @@ from .config import gcs_config
 GCSOperationResult = TypeVar("GCSOperationResult")
 
 
+# Global client to share connection pool across multiple requests
+gcs_client = storage.Client()
+
+
 class GCSService:
     """Service class for GCS file operations: routing, moving, and metadata extraction.
 
@@ -15,13 +19,15 @@ class GCSService:
     of custom metadata (x-goog-meta-*) used in the classification process.
     """
 
+    client = gcs_client
+
     def __init__(self) -> None:
         """Initializes the GCS client using Application Default Credentials (ADC).
 
         Returns:
             None
         """
-        self.client = storage.Client()
+        pass
 
     def _execute_with_exponential_backoff(
         self, operation: Callable[..., GCSOperationResult], *args: Any, **kwargs: Any

--- a/pipelines/enterprise_knowledge_base/app/document_classification/gcs_service/service.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/gcs_service/service.py
@@ -21,14 +21,6 @@ class GCSService:
 
     client = gcs_client
 
-    def __init__(self) -> None:
-        """Initializes the GCS client using Application Default Credentials (ADC).
-
-        Returns:
-            None
-        """
-        pass
-
     def _execute_with_exponential_backoff(
         self, operation: Callable[..., GCSOperationResult], *args: Any, **kwargs: Any
     ) -> GCSOperationResult:

--- a/pipelines/enterprise_knowledge_base/app/document_classification/gemini_service/service.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/gemini_service/service.py
@@ -7,16 +7,22 @@ from ..config import EKB_CONFIG
 from .schemas import ContextualClassificationResponse
 
 
+# Global client to share connection pool across multiple requests
+gemini_client = genai.Client(
+    vertexai=True,
+    project=EKB_CONFIG.PROJECT_ID,
+    location=EKB_CONFIG.GEMINI_LOCATION,
+)
+
+
 class GeminiService:
     """Service to interact with Gemini 2.5 Flash on Vertex AI."""
 
+    client = gemini_client
+
     def __init__(self) -> None:
         """Initializes the Vertex AI Gemini client."""
-        self.client = genai.Client(
-            vertexai=True,
-            project=EKB_CONFIG.PROJECT_ID,
-            location=EKB_CONFIG.GEMINI_LOCATION,
-        )
+        pass
 
     def classify_document(
         self,

--- a/pipelines/enterprise_knowledge_base/app/document_classification/gemini_service/service.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/gemini_service/service.py
@@ -20,10 +20,6 @@ class GeminiService:
 
     client = gemini_client
 
-    def __init__(self) -> None:
-        """Initializes the Vertex AI Gemini client."""
-        pass
-
     def classify_document(
         self,
         gcs_uri: str,

--- a/pipelines/enterprise_knowledge_base/app/jobs.py
+++ b/pipelines/enterprise_knowledge_base/app/jobs.py
@@ -8,11 +8,16 @@ from .schemas import JobStatus, JobStatusResponse
 from .document_classification.config import EKB_CONFIG
 
 
+# Global client to share connection pool across multiple requests
+bq_client = bigquery.Client(project=EKB_CONFIG.PROJECT_ID)
+
+
 class JobService:
     """Manages the persistence of ingestion job statuses in BigQuery."""
 
+    bq_client = bq_client
+
     def __init__(self):
-        self.bq_client = bigquery.Client(project=EKB_CONFIG.PROJECT_ID)
         self.table_id = f"{EKB_CONFIG.PROJECT_ID}.{EKB_CONFIG.BQ_DATASET}.{EKB_CONFIG.BQ_JOBS_TABLE}"
 
     def create_job(self, filename: str) -> str:

--- a/pipelines/enterprise_knowledge_base/app/main.py
+++ b/pipelines/enterprise_knowledge_base/app/main.py
@@ -18,6 +18,7 @@ app = FastAPI(
 )
 
 job_service = JobService()
+ekb_pipeline = KBIngestionPipeline(EKB_CONFIG.PROJECT_ID)
 
 
 def run_pipeline_task(job_id: str, request: OrchestratorRunRequest) -> None:
@@ -34,8 +35,7 @@ def run_pipeline_task(job_id: str, request: OrchestratorRunRequest) -> None:
     """
     logger.info(f"Starting background pipeline for job {job_id}")
     try:
-        pipeline = KBIngestionPipeline(EKB_CONFIG.PROJECT_ID)
-        result = pipeline.run(request)
+        result = ekb_pipeline.run(request)
 
         # Extract metadata for status update
         metadata = {

--- a/pipelines/enterprise_knowledge_base/app/rag_ingestion/pipeline.py
+++ b/pipelines/enterprise_knowledge_base/app/rag_ingestion/pipeline.py
@@ -21,6 +21,11 @@ from .schemas import (
 GCSOperationResult = TypeVar("GCSOperationResult")
 
 
+# Global clients to share connection pools across multiple requests
+storage_client = storage.Client(project=RAG_CONFIG.PROJECT_ID)
+bq_client = bigquery.Client(project=RAG_CONFIG.PROJECT_ID)
+
+
 class RAGIngestion:
     """Parses documents into structural chunks and stages them in BigQuery.
 
@@ -28,14 +33,15 @@ class RAGIngestion:
     including PDF parsing, chunking, BigQuery staging, and vectorization.
     """
 
+    storage_client = storage_client
+    bq_client = bq_client
+
     def __init__(self) -> None:
         """Initializes the RAG Ingestion with GCP clients and configuration.
 
         Returns:
             None -> No return value.
         """
-        self.storage_client = storage.Client(project=RAG_CONFIG.PROJECT_ID)
-        self.bq_client = bigquery.Client(project=RAG_CONFIG.PROJECT_ID)
         self.table_id = f"{RAG_CONFIG.PROJECT_ID}.{RAG_CONFIG.BQ_DATASET}.{RAG_CONFIG.BQ_CHUNKS_TABLE}"
         logger.info(
             f"Initialized RAGIngestion | CHUNK_SIZE: {RAG_CONFIG.CHUNK_SIZE} | OVERLAP: {RAG_CONFIG.CHUNK_OVERLAP}"

--- a/pipelines/enterprise_knowledge_base/tests/test_rag_ingestion.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_rag_ingestion.py
@@ -30,7 +30,7 @@ def mock_config():
 @pytest.fixture
 def mock_storage():
     with patch(
-        "pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline.storage.Client"
+        "pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline.RAGIngestion.storage_client"
     ) as mock:
         yield mock
 
@@ -38,16 +38,15 @@ def mock_storage():
 @pytest.fixture
 def mock_bq():
     with patch(
-        "pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline.bigquery.Client"
+        "pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline.RAGIngestion.bq_client"
     ) as mock:
-        mock_client = mock.return_value
         mock_query_job = MagicMock()
 
         # By default, return empty result to pass _is_document_processed
         mock_query_job.result.return_value = []
         mock_query_job.num_dml_affected_rows = 1
 
-        mock_client.query.return_value = mock_query_job
+        mock.query.return_value = mock_query_job
         yield mock
 
 
@@ -75,20 +74,18 @@ def test_ingest_document_success(mock_storage, mock_bq, mock_fitz):
     assert response.processed_uri == "gs://test-bucket/ingested/test.pdf"
 
     # Verify BQ calls
-    mock_bq_client = mock_bq.return_value
-    mock_bq_client.load_table_from_json.assert_called_once()
+    mock_bq.load_table_from_json.assert_called_once()
 
     # Verify GCS calls (should be 2 copies: Domain -> Staging, Staging Ingested -> Staging Processed)
-    mock_bucket = mock_storage.return_value.bucket.return_value
+    mock_bucket = mock_storage.bucket.return_value
     assert mock_bucket.copy_blob.call_count == 2
 
 
 def test_ingest_document_already_processed(mock_storage, mock_bq, mock_fitz):
     service = RAGIngestion()
-    mock_bq_client = mock_bq.return_value
     mock_query_job = MagicMock()
     mock_query_job.result.return_value = [{"dummy": 1}]
-    mock_bq_client.query.return_value = mock_query_job
+    mock_bq.query.return_value = mock_query_job
 
     request = IngestDocumentRequest(gcs_uri="gs://test-bucket/ingested/test.pdf")
     response = service.ingest_document(request)
@@ -103,22 +100,20 @@ def test_generate_embeddings_success(mock_bq):
     request = GenerateEmbeddingsRequest(gcs_uri="gs://test-bucket/processed/test.pdf")
 
     # Mock the verify query explicitly since we changed the default mock behavior
-    mock_bq_client = mock_bq.return_value
     mock_result = MagicMock()
     mock_result.count = 1
     mock_query_job = MagicMock()
     mock_query_job.result.return_value = iter([mock_result])
     mock_query_job.num_dml_affected_rows = 1
-    mock_bq_client.query.return_value = mock_query_job
+    mock_bq.query.return_value = mock_query_job
 
     response = service.generate_embeddings(request)
 
     assert response.success is True
     assert "SUCCESS" in response.execution_status
 
-    mock_bq_client = mock_bq.return_value
-    assert mock_bq_client.query.call_count == 2
-    args, kwargs = mock_bq_client.query.call_args_list[0]
+    assert mock_bq.query.call_count == 2
+    args, kwargs = mock_bq.query.call_args_list[0]
     query_str = args[0]
 
     assert (
@@ -129,8 +124,7 @@ def test_generate_embeddings_success(mock_bq):
 
 def test_generate_embeddings_failure(mock_bq):
     service = RAGIngestion()
-    mock_bq_client = mock_bq.return_value
-    mock_bq_client.query.side_effect = Exception("BQ Error")
+    mock_bq.query.side_effect = Exception("BQ Error")
 
     request = GenerateEmbeddingsRequest(gcs_uri="gs://test-bucket/processed/test.pdf")
     response = service.generate_embeddings(request)


### PR DESCRIPTION
## Description
This PR resolves the intermittent `SSLEOFError` and connection drop issues during concurrent multi-file ingestion through the EKB pipeline. 

### Root Cause
FastAPI's `BackgroundTasks` was instantiating a new `KBIngestionPipeline` (and therefore new `GCSService`, `RAGIngestion`, `BQService`, etc.) for every incoming request. Because each service instantiated a new `storage.Client()` or `bigquery.Client()` in its `__init__`, the underlying `urllib3` HTTP connection pools were bypassed and rapidly exhausted.

### Solution
Refactored all pipeline services to leverage a module-level global client instantiated via a Class Attribute pattern (`client = bq_client`).
This ensures that all concurrent background tasks natively share the same Google Cloud SDK clients and underlying TCP connection pools. 

Furthermore, the `KBIngestionPipeline` orchestrator was elevated to a module-level singleton in `main.py`.

### Changes
- `jobs.py`
- `main.py`
- `bq_service/service.py`
- `dlp_service/service.py`
- `gemini_service/service.py`
- `gcs_service/service.py`
- `rag_ingestion/pipeline.py`