### PR TITLE
MCP Servers / Cloud Storage - Implement SA Switching for update_object_metadata

### DIFF
--- a/mcp_servers/gcs/README.md
+++ b/mcp_servers/gcs/README.md
@@ -79,8 +79,8 @@ Expected outcomes:
 This server includes a specialized ingestion pipeline designed to move data securely from a Landing Zone to a Knowledge Base.
 
 ### Automated Auth Switching
-- **Internal Pipeline**: If moving from `ai_agent_landing_zone` to `kb-landing-zone`, the server uses its own **Service Account (SA)**.
-- **User Operations**: For all other moves, it enforces the **Delegated OAuth Token** of the requesting user.
+- **Internal Pipeline**: If moving from `ai_agent_landing_zone` to `kb-landing-zone` (via `upload_object`) or updating metadata for objects in `kb-landing-zone` (via `update_object_metadata`), the server uses its own **Service Account (SA)**.
+- **User Operations**: For all other buckets and operations, it enforces the **Delegated OAuth Token** of the requesting user to maintain strict IAM boundaries.
 
 For full technical details on URI-based ingestion and path construction, see [INGESTION.md](./INGESTION.md).
 

--- a/mcp_servers/gcs/app/mcp_server.py
+++ b/mcp_servers/gcs/app/mcp_server.py
@@ -277,6 +277,7 @@ async def update_object_metadata(
 ) -> UpdateObjectMetadataResponse:
     """
     Updates the metadata of an existing object in GCS, such as content-type or custom metadata.
+    This tool implements automated SA switching for restricted ingestion buckets.
 
     Args:
         request: UpdateObjectMetadataRequest -> The request parameters for updating metadata.
@@ -289,7 +290,10 @@ async def update_object_metadata(
         f"bucket_name={request.bucket_name}, object_name={request.object_name})"
     )
     try:
-        gcs_manager = _make_gcs_manager()
+        # Determine Authentication Strategy
+        use_sa = request.bucket_name == GCS_SERVER_CONFIG.kb_ingestion_bucket
+
+        gcs_manager = _make_gcs_manager(use_sa=use_sa)
         blob = await asyncio.to_thread(
             gcs_manager.update_object_metadata,
             request.bucket_name,

--- a/mcp_servers/gcs/app/mcp_server.py
+++ b/mcp_servers/gcs/app/mcp_server.py
@@ -176,9 +176,15 @@ async def upload_object(request: UploadObjectRequest) -> UploadObjectResponse:
         # 1. Determine Authentication Strategy
         # Logic: Use SA ONLY for internal landing-zone to KB pipeline.
         use_sa = (
-            request.source_bucket == GCS_SERVER_CONFIG.landing_zone_bucket
-            and request.destination_bucket == GCS_SERVER_CONFIG.kb_ingestion_bucket
+            request.source_bucket.lower()
+            == GCS_SERVER_CONFIG.landing_zone_bucket.lower()
+            and request.destination_bucket.lower()
+            == GCS_SERVER_CONFIG.kb_ingestion_bucket.lower()
         )
+        if use_sa:
+            logger.info(
+                f"Using Service Account for restricted ingestion to {request.destination_bucket}"
+            )
 
         # 2. Execute Copy Operation
         gcs_manager = _make_gcs_manager(use_sa=use_sa)
@@ -291,7 +297,13 @@ async def update_object_metadata(
     )
     try:
         # Determine Authentication Strategy
-        use_sa = request.bucket_name == GCS_SERVER_CONFIG.kb_ingestion_bucket
+        use_sa = (
+            request.bucket_name.lower() == GCS_SERVER_CONFIG.kb_ingestion_bucket.lower()
+        )
+        if use_sa:
+            logger.info(
+                f"Using Service Account for metadata update on restricted bucket {request.bucket_name}"
+            )
 
         gcs_manager = _make_gcs_manager(use_sa=use_sa)
         blob = await asyncio.to_thread(

--- a/mcp_servers/gcs/tests/test_mcp_server.py
+++ b/mcp_servers/gcs/tests/test_mcp_server.py
@@ -10,6 +10,7 @@ from mcp_servers.gcs.app.mcp_server import (
     list_buckets,
     read_object,
     upload_object,
+    update_object_metadata,
 )
 from mcp_servers.gcs.app.config import GCS_API_CONFIG, GCS_SERVER_CONFIG
 from mcp_servers.gcs.app.schemas import (
@@ -18,6 +19,7 @@ from mcp_servers.gcs.app.schemas import (
     ListBucketsRequest,
     ReadObjectRequest,
     UploadObjectRequest,
+    UpdateObjectMetadataRequest,
 )
 
 
@@ -264,3 +266,25 @@ def test_make_gcs_manager_uses_sa_credentials_when_requested():
     mock_manager.assert_called_once_with(
         "sa-creds", default_project=GCS_SERVER_CONFIG.default_project_id
     )
+
+
+def test_mcp_update_object_metadata_success_sa_flow(mock_gcs_manager):
+    mock_blob = MagicMock()
+    mock_blob.metadata = {"project": "test"}
+    mock_blob.content_type = "application/pdf"
+    mock_gcs_manager.update_object_metadata.return_value = mock_blob
+
+    # Config value: kb_ingestion_bucket="kb-landing-zone"
+    request = UpdateObjectMetadataRequest(
+        bucket_name="kb-landing-zone",
+        object_name="test.pdf",
+        metadata={"project": "test"},
+    )
+    with patch("mcp_servers.gcs.app.mcp_server._make_gcs_manager") as mock_make:
+        mock_make.return_value = mock_gcs_manager
+        result = asyncio.run(update_object_metadata(request))
+        # Ensure it was called with use_sa=True
+        mock_make.assert_called_with(use_sa=True)
+
+    assert result.execution_status == "success"
+    mock_gcs_manager.update_object_metadata.assert_called_once()


### PR DESCRIPTION
## Summary
This PR implements automated Service Account (SA) switching for the  tool in the GCS MCP server. This allows the agent to stamp metadata on blobs in the restricted Knowledge Base landing zone bucket without requiring the user to have direct write permissions.

## Changes
- Modified  to add SA switching logic.
- Added  to .
- Updated  to document the security pattern.