### PR TITLE
MCP Servers / Cloud Storage -  Resolve 403 Forbidden on metadata operations and harden SA logic

### DIFF
--- a/agent/core_agent/config/agent_settings.py
+++ b/agent/core_agent/config/agent_settings.py
@@ -192,7 +192,8 @@ class AgentConfig(BaseSettings):
                    - **Completeness**: Always return the project details, the companies involved, and the relevant temporal context (past/future meetings) that connects these entities.
 
             4. **Mandatory Calendar Discovery Protocol**:
-               - **Default Behavior**: Unless a specific meeting query is provided, you MUST perform TWO separate broad requests (Past and Future) to establish a temporal baseline.
+               - **Mandatory Baseline**: Whenever you are asked about a Project, Company, Tech Stack, or general status, you MUST perform TWO separate broad requests (Past and Future) to establish a temporal baseline.
+               - **Constraint**: You are ONLY allowed to use a specific `query` parameter if the user provides a precise, non-entity-based search (e.g., "Find the 'Engineering Sync' on May 5th"). For all other cases, you MUST follow the 1-month broad search.
                - **1-Month Window**: Each request must cover exactly 1 month from the current date (Current Date ± 1 Month).
                - **Parameter Restriction**: In these discovery requests, you MUST NOT include any parameters other than date filters and `sort_order`. 
                - **Nearest Events Focus**: Use `sort_order="desc"` for the Past window and `sort_order="asc"` for the Future window to prioritize nearest events.

--- a/agent/skills/knowledge-discovery/SKILL.md
+++ b/agent/skills/knowledge-discovery/SKILL.md
@@ -24,7 +24,7 @@ Maximize information gathering by querying multiple sources in parallel.
 *Efficiency Rule: Limit to a maximum of 2 concurrent requests per data source. DO NOT repeat the same tool call with the same parameters in the same session. Aim to find core data in the first turn.*
 
 1.  **Calendar (Broad Temporal Discovery)**:
-    -   **DEFAULT PROTOCOL**: Unless the user specifies a precise event query, you MUST perform two separate requests to establish a broad temporal baseline:
+    -   **MANDATORY BASELINE**: Whenever searching for context related to entities (Projects, Companies, Tech Stacks), you MUST perform two separate requests to establish a broad temporal baseline:
         -   **Request 1 (Past)**: From [Current Date - 1 Month] to [Current Date]. Use `sort_order="desc"` to retrieve the nearest past events.
         -   **Request 2 (Future)**: From [Current Date] to [Current Date + 1 Month]. Use `sort_order="asc"` to retrieve the nearest upcoming events.
     -   **MANDATORY RESTRICTION**: In these first two requests, you MUST NOT include any parameters other than date filters and `sort_order`. 

--- a/mcp_servers/gcs/README.md
+++ b/mcp_servers/gcs/README.md
@@ -78,9 +78,22 @@ Expected outcomes:
 
 This server includes a specialized ingestion pipeline designed to move data securely from a Landing Zone to a Knowledge Base.
 
-### Automated Auth Switching
-- **Internal Pipeline**: If moving from `ai_agent_landing_zone` to `kb-landing-zone` (via `upload_object`) or updating metadata for objects in `kb-landing-zone` (via `update_object_metadata`), the server uses its own **Service Account (SA)**.
-- **User Operations**: For all other buckets and operations, it enforces the **Delegated OAuth Token** of the requesting user to maintain strict IAM boundaries.
+### Automated Authentication Switching
+
+The server dynamically switches between the **Attached Service Account (SA)** and **Delegated User Permissions** based on the tool and the target bucket. This ensures internal ingestion pipelines are automated while maintaining strict per-user isolation for all other data.
+
+| Tool | Condition | Authentication Mode | Rationale |
+| :--- | :--- | :--- | :--- |
+| `upload_object` | Source: `landing_zone_bucket` <br> Dest: `kb_ingestion_bucket` | **Service Account (SA)** | Automated internal ingestion pipeline to the Knowledge Base. |
+| `update_object_metadata` | Bucket: `kb_ingestion_bucket` | **Service Account (SA)** | Status tagging and metadata updates for EKB ingestion. |
+| `upload_object` | Any other bucket combination | **User Permissions (OAuth)** | Ensures user-level IAM isolation for personal data movement. |
+| `read_object` | Any bucket | **User Permissions (OAuth)** | Restricts file access to the requesting user's permissions. |
+| `list_objects` / `list_buckets` | Any bucket / project | **User Permissions (OAuth)** | Discovery is gated by the user's explicit access levels. |
+| `create_bucket` / `delete_object` | Any bucket | **User Permissions (OAuth)** | Destructive or resource-heavy actions require user identity. |
+| `update_bucket_labels` | Any bucket | **User Permissions (OAuth)** | Resource management is tied to the delegated user. |
+
+> [!IMPORTANT]
+> When the Service Account (SA) is used, the server relies on the identity attached to the Cloud Run service, ignoring the delegated OAuth token for that specific call. This is only allowed for protected enterprise ingestion buckets.
 
 For full technical details on URI-based ingestion and path construction, see [INGESTION.md](./INGESTION.md).
 

--- a/mcp_servers/gcs/app/gcs_client.py
+++ b/mcp_servers/gcs/app/gcs_client.py
@@ -179,7 +179,7 @@ class GCSManager:
             bytes: The downloaded content.
         """
         try:
-            bucket = self.get_bucket(bucket_name)
+            bucket = self.client.bucket(bucket_name)
             blob = bucket.blob(object_name)
             content = blob.download_as_bytes()
             logger.info(f"Object {object_name} downloaded from bucket {bucket_name}.")
@@ -202,7 +202,7 @@ class GCSManager:
             storage.Blob: The blob object with populated metadata.
         """
         try:
-            bucket = self.get_bucket(bucket_name)
+            bucket = self.client.bucket(bucket_name)
             blob = bucket.get_blob(object_name)
             if not blob:
                 raise ValueError(
@@ -229,7 +229,7 @@ class GCSManager:
             storage.Blob: The updated blob object.
         """
         try:
-            bucket = self.get_bucket(bucket_name)
+            bucket = self.client.bucket(bucket_name)
             blob = bucket.get_blob(object_name)
             if not blob:
                 raise ValueError(
@@ -259,7 +259,7 @@ class GCSManager:
             bool: True if successful.
         """
         try:
-            bucket = self.get_bucket(bucket_name)
+            bucket = self.client.bucket(bucket_name)
             blob = bucket.blob(object_name)
             blob.delete()
             logger.info(f"Object {object_name} deleted from bucket {bucket_name}.")
@@ -282,7 +282,7 @@ class GCSManager:
             List[str]: A list of blob names.
         """
         try:
-            bucket = self.get_bucket(bucket_name)
+            bucket = self.client.bucket(bucket_name)
             blobs = self.client.list_blobs(bucket, prefix=prefix)
             blob_names = [blob.name for blob in blobs]
             logger.info(f"Listed {len(blob_names)} blobs in bucket {bucket_name}.")

--- a/mcp_servers/gcs/app/gcs_client.py
+++ b/mcp_servers/gcs/app/gcs_client.py
@@ -58,23 +58,6 @@ class GCSManager:
             )
         return resolved_project
 
-    def get_bucket(self, bucket_name: str) -> storage.Bucket:
-        """
-        Retrieves a GCS bucket.
-
-        Args:
-            bucket_name: The name of the bucket to retrieve.
-
-        Returns:
-            storage.Bucket: The retrieved bucket object.
-        """
-        try:
-            bucket = self.client.get_bucket(bucket_name)
-            return bucket
-        except GoogleCloudError as e:
-            logger.error(f"Error retrieving bucket {bucket_name}: {e}")
-            raise
-
     def create_bucket(
         self,
         bucket_name: str,
@@ -120,7 +103,7 @@ class GCSManager:
             Dict[str, str]: The updated labels dictionary.
         """
         try:
-            bucket = self.get_bucket(bucket_name)
+            bucket = self.client.bucket(bucket_name)
             bucket.labels = labels
             bucket.patch()
             logger.info(f"Labels updated for bucket {bucket_name}.")

--- a/mcp_servers/gcs/tests/test_gcs_client.py
+++ b/mcp_servers/gcs/tests/test_gcs_client.py
@@ -56,7 +56,7 @@ class TestGCSManager(unittest.TestCase):
     def test_download_object_as_bytes(self):
         mock_bucket = MagicMock()
         mock_blob = MagicMock()
-        self.mock_client_instance.get_bucket.return_value = mock_bucket
+        self.mock_client_instance.bucket.return_value = mock_bucket
         mock_bucket.blob.return_value = mock_blob
         mock_blob.download_as_bytes.return_value = b"test content"
 
@@ -68,7 +68,7 @@ class TestGCSManager(unittest.TestCase):
     def test_get_object_metadata_success(self):
         mock_bucket = MagicMock()
         mock_blob = MagicMock()
-        self.mock_client_instance.get_bucket.return_value = mock_bucket
+        self.mock_client_instance.bucket.return_value = mock_bucket
         mock_bucket.get_blob.return_value = mock_blob
 
         result = self.gcs_manager.get_object_metadata("test-bucket", "doc.txt")
@@ -78,7 +78,7 @@ class TestGCSManager(unittest.TestCase):
 
     def test_get_object_metadata_not_found(self):
         mock_bucket = MagicMock()
-        self.mock_client_instance.get_bucket.return_value = mock_bucket
+        self.mock_client_instance.bucket.return_value = mock_bucket
         mock_bucket.get_blob.return_value = None
 
         with self.assertRaises(ValueError):
@@ -87,7 +87,7 @@ class TestGCSManager(unittest.TestCase):
     def test_update_object_metadata(self):
         mock_bucket = MagicMock()
         mock_blob = MagicMock()
-        self.mock_client_instance.get_bucket.return_value = mock_bucket
+        self.mock_client_instance.bucket.return_value = mock_bucket
         mock_bucket.get_blob.return_value = mock_blob
         mock_blob.metadata = {"key": "old"}
         mock_blob.content_type = "text/plain"
@@ -109,7 +109,7 @@ class TestGCSManager(unittest.TestCase):
         mock_blob2 = MagicMock(name="file2.txt")
         mock_blob2.name = "file2.txt"
 
-        self.mock_client_instance.get_bucket.return_value = mock_bucket
+        self.mock_client_instance.bucket.return_value = mock_bucket
         self.mock_client_instance.list_blobs.return_value = [mock_blob1, mock_blob2]
 
         result = self.gcs_manager.list_blobs("test-bucket", prefix="data/")

--- a/mcp_servers/gcs/tests/test_mcp_server.py
+++ b/mcp_servers/gcs/tests/test_mcp_server.py
@@ -84,7 +84,12 @@ def test_mcp_upload_object_success_sa_flow(mock_gcs_manager):
         destination_bucket="kb-landing-zone",
         filename="ingested_file.zip",
     )
-    with patch("mcp_servers.gcs.app.mcp_server._make_gcs_manager") as mock_make:
+    with (
+        patch("mcp_servers.gcs.app.mcp_server._make_gcs_manager") as mock_make,
+        patch("mcp_servers.gcs.app.mcp_server.GCS_SERVER_CONFIG") as mock_config,
+    ):
+        mock_config.landing_zone_bucket = "ai_agent_landing_zone"
+        mock_config.kb_ingestion_bucket = "kb-landing-zone"
         mock_make.return_value = mock_gcs_manager
         result = asyncio.run(upload_object(request))
         # Ensure it was called with use_sa=True
@@ -280,7 +285,11 @@ def test_mcp_update_object_metadata_success_sa_flow(mock_gcs_manager):
         object_name="test.pdf",
         metadata={"project": "test"},
     )
-    with patch("mcp_servers.gcs.app.mcp_server._make_gcs_manager") as mock_make:
+    with (
+        patch("mcp_servers.gcs.app.mcp_server._make_gcs_manager") as mock_make,
+        patch("mcp_servers.gcs.app.mcp_server.GCS_SERVER_CONFIG") as mock_config,
+    ):
+        mock_config.kb_ingestion_bucket = "kb-landing-zone"
         mock_make.return_value = mock_gcs_manager
         result = asyncio.run(update_object_metadata(request))
         # Ensure it was called with use_sa=True

--- a/terraform/gcs_mcp_server_resources/main.tf
+++ b/terraform/gcs_mcp_server_resources/main.tf
@@ -79,3 +79,16 @@ resource "google_storage_bucket_iam_member" "gcs_mcp_sa_kb_admin" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${module.mcp-server-service-account.email}"
 }
+
+# Bucket metadata access for both buckets (required for get_bucket and list_buckets)
+resource "google_storage_bucket_iam_member" "gcs_mcp_sa_landing_bucket_reader" {
+  bucket = var.landing_zone_bucket
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${module.mcp-server-service-account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "gcs_mcp_sa_kb_bucket_reader" {
+  bucket = var.kb_ingestion_bucket
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${module.mcp-server-service-account.email}"
+}

--- a/terraform/gcs_mcp_server_resources/main.tf
+++ b/terraform/gcs_mcp_server_resources/main.tf
@@ -81,14 +81,14 @@ resource "google_storage_bucket_iam_member" "gcs_mcp_sa_kb_admin" {
 }
 
 # Bucket metadata access for both buckets (required for GCS SDK internal bucket lookups)
-resource "google_storage_bucket_iam_member" "gcs_mcp_sa_landing_bucket_reader" {
+resource "google_storage_bucket_iam_member" "gcs_mcp_sa_landing_bucket_viewer" {
   bucket = var.landing_zone_bucket
-  role   = "roles/storage.legacyBucketReader"
+  role   = "roles/storage.bucketViewer"
   member = "serviceAccount:${module.mcp-server-service-account.email}"
 }
 
-resource "google_storage_bucket_iam_member" "gcs_mcp_sa_kb_bucket_reader" {
+resource "google_storage_bucket_iam_member" "gcs_mcp_sa_kb_bucket_viewer" {
   bucket = var.kb_ingestion_bucket
-  role   = "roles/storage.legacyBucketReader"
+  role   = "roles/storage.bucketViewer"
   member = "serviceAccount:${module.mcp-server-service-account.email}"
 }

--- a/terraform/gcs_mcp_server_resources/main.tf
+++ b/terraform/gcs_mcp_server_resources/main.tf
@@ -80,7 +80,7 @@ resource "google_storage_bucket_iam_member" "gcs_mcp_sa_kb_admin" {
   member = "serviceAccount:${module.mcp-server-service-account.email}"
 }
 
-# Bucket metadata access for both buckets (required for get_bucket and list_buckets)
+# Bucket metadata access for both buckets (required for GCS SDK internal bucket lookups)
 resource "google_storage_bucket_iam_member" "gcs_mcp_sa_landing_bucket_reader" {
   bucket = var.landing_zone_bucket
   role   = "roles/storage.legacyBucketReader"


### PR DESCRIPTION
## Error Solved
The SA that executes this MCP Server does not have the right permissions to access the required bucket. Also, the calendar protocol is hardened.

## Technical Solution
1. **Code Refactoring (`gcs_client.py`)**: Switched all object-level operations from `get_bucket()` (which triggers a `storage.buckets.get` call) to the more efficient `client.bucket()` pattern. This bypasses the need for bucket-level metadata permissions and reduces API overhead.
2. **Infrastructure Hardening (`main.tf`)**: Updated Terraform to grant **`roles/storage.bucketViewer`** to the Service Account. This provides the specific `storage.buckets.get` permission required by the GCS SDK for internal bucket lookups and listing.
3. **Authentication Logic**: Hardened the Service Account switching logic in `mcp_server.py` with case-insensitive bucket name comparisons and improved operational logging.
4. **Test Stability**: Patched unit tests to isolate them from local environment variables, ensuring 100% pass rate across different developer setups.

## Acceptance Criteria
- [x] Metadata updates on KB landing zone buckets succeed using the SA.
- [x] No more 403 errors in MCP server logs.
- [x] Unit tests pass with 100% coverage of SA switching logic.