### PR TITLE
AI Agent / Refactor - Multi-Agent Architecture (Coordinator + Research + Ingestion Specialists)

### DIFF
--- a/agent/core_agent/agent.py
+++ b/agent/core_agent/agent.py
@@ -62,8 +62,15 @@ ingestion_agent = (
         auth_config=GOOGLE_AUTH_CONFIG,
     )
     .with_skills(["kb-file-ingestion"])
+    .with_mcp_servers(
+        [
+            BIGQUERY_MCP_CONFIG,
+            GCS_MCP_CONFIG,
+        ]
+    )
     .with_native_tools(
         [
+            GetArtifactUriTool(),
             TriggerEKBPipelineTool(),
             CheckIngestionStatusTool(),
             load_artifacts,

--- a/agent/core_agent/agent.py
+++ b/agent/core_agent/agent.py
@@ -3,7 +3,9 @@ from google.adk.tools import load_artifacts
 from .builder import AgentBuilder, AppBuilder
 from .config import (
     GCP_CONFIG,
-    AGENT_CONFIG,
+    COORDINATOR_CONFIG,
+    RESEARCH_AGENT_CONFIG,
+    INGESTION_AGENT_CONFIG,
     BIGQUERY_MCP_CONFIG,
     CALENDAR_MCP_CONFIG,
     DRIVE_MCP_CONFIG,
@@ -20,46 +22,75 @@ from .tools.time_tools import GetCurrentTimeTool
 from .callbacks.ingestion_status import sync_ingestion_status
 from loguru import logger
 
-mcp_servers_to_mount = [
-    BIGQUERY_MCP_CONFIG,
-    DRIVE_MCP_CONFIG,
-    CALENDAR_MCP_CONFIG,
-    GCS_MCP_CONFIG,
-]
-
-skills_to_mount = [
-    "meeting-summary",
-    "kb-file-ingestion",
-    "knowledge-discovery",
-]
-
-
-root_agent = (
+# ---------------------------------------------------------------------------
+# 1. Research & Meetings Specialist
+# ---------------------------------------------------------------------------
+research_agent = (
     AgentBuilder(
-        agent_config=AGENT_CONFIG,
+        agent_config=RESEARCH_AGENT_CONFIG,
         gcp_config=GCP_CONFIG,
         auth_config=GOOGLE_AUTH_CONFIG,
     )
-    .with_skills(skills_to_mount)
-    .with_mcp_servers(mcp_servers_to_mount)
-    .with_before_agent_callback(sync_ingestion_status)
+    .with_skills(["meeting-summary", "knowledge-discovery"])
+    .with_mcp_servers(
+        [
+            BIGQUERY_MCP_CONFIG,
+            DRIVE_MCP_CONFIG,
+            CALENDAR_MCP_CONFIG,
+            GCS_MCP_CONFIG,
+        ]
+    )
     .with_native_tools(
         [
             GetArtifactUriTool(),
             ImportGcsToArtifactTool(),
-            TriggerEKBPipelineTool(),
-            CheckIngestionStatusTool(),
             GetCurrentTimeTool(),
             load_artifacts,
         ]
     )
+    .with_output_key("research_context")
+    .build()
+)
+
+# ---------------------------------------------------------------------------
+# 2. Ingestion Specialist
+# ---------------------------------------------------------------------------
+ingestion_agent = (
+    AgentBuilder(
+        agent_config=INGESTION_AGENT_CONFIG,
+        gcp_config=GCP_CONFIG,
+        auth_config=GOOGLE_AUTH_CONFIG,
+    )
+    .with_skills(["kb-file-ingestion"])
+    .with_native_tools(
+        [
+            TriggerEKBPipelineTool(),
+            CheckIngestionStatusTool(),
+            load_artifacts,
+        ]
+    )
+    .build(enable_artifact_rendering=False)
+)
+
+# ---------------------------------------------------------------------------
+# 3. Coordinator (Root Agent)
+# ---------------------------------------------------------------------------
+root_agent = (
+    AgentBuilder(
+        agent_config=COORDINATOR_CONFIG,
+        gcp_config=GCP_CONFIG,
+        auth_config=GOOGLE_AUTH_CONFIG,
+    )
+    .with_subagents([research_agent, ingestion_agent])
+    .with_before_agent_callback(sync_ingestion_status)
+    .with_native_tools([GetArtifactUriTool(), load_artifacts])
     .build()
 )
 
 app = AppBuilder(
     agent=root_agent,
     gcp_config=GCP_CONFIG,
-    agent_config=AGENT_CONFIG,
+    agent_config=COORDINATOR_CONFIG,
 ).build()
 
-logger.info("ADK Agent application initialized and ready for execution.")
+logger.info("ADK Multi-Agent application initialized and ready for execution.")

--- a/agent/core_agent/builder/agent_builder.py
+++ b/agent/core_agent/builder/agent_builder.py
@@ -1,4 +1,4 @@
-from typing import Callable, Self, Union
+from typing import Callable, Optional, Self, Union
 
 import vertexai
 from google.adk.agents import Agent
@@ -15,7 +15,7 @@ from google.genai.types import (
 )
 from loguru import logger
 
-from ..config import AgentConfig, BaseMCPConfig, GCPConfig, GoogleAuthConfig
+from ..config import BaseAgentConfig, BaseMCPConfig, GCPConfig, GoogleAuthConfig
 from google.adk.tools.skill_toolset import SkillToolset
 from ..callbacks.artifact_rendering import render_pending_artifacts
 from .mcp_factory import MCPToolsetBuilder
@@ -27,14 +27,14 @@ class AgentBuilder:
 
     def __init__(
         self,
-        agent_config: AgentConfig,
+        agent_config: BaseAgentConfig,
         gcp_config: GCPConfig,
         auth_config: GoogleAuthConfig,
     ) -> None:
         """Initializes the AgentBuilder, configures the VertexAI client, and sets up the MCP toolset builder.
 
         Args:
-            agent_config: AgentConfig -> Core agent behavioural settings.
+            agent_config: BaseAgentConfig -> Core agent behavioural settings.
             gcp_config: GCPConfig -> Google Cloud Platform project settings.
             auth_config: GoogleAuthConfig -> Shared authentication parameters.
         """
@@ -42,8 +42,10 @@ class AgentBuilder:
         self.gcp_config = gcp_config
         self._mcp_builder = MCPToolsetBuilder(auth_config)
         self._registered_tools = []
+        self._sub_agents: list[Agent] = []
         self._skills = []
         self._before_callback = None
+        self._output_key: Optional[str] = None
 
         # Initialize VertexAI natively
         vertexai.Client(
@@ -53,6 +55,24 @@ class AgentBuilder:
         logger.info(
             f"AgentBuilder initialized VertexAI via {self.gcp_config.PROJECT_ID}/{self.gcp_config.REGION}"
         )
+
+    def with_subagents(self, sub_agents: list[Agent]) -> Self:
+        """Registers specialist agents for LLM-transfer delegation via sub_agents= parameter.
+
+        Using sub_agents= (vs. AgentTool) keeps specialists in the same invocation
+        context: OAuth challenges, file_data content, and after_agent_callbacks all
+        propagate correctly to the user.
+
+        Args:
+            sub_agents: list[Agent] -> List of fully configured ADK agents to register.
+
+        Returns:
+            Self -> The builder instance for fluent chaining.
+        """
+        for sub_agent in sub_agents:
+            logger.info(f"Registering sub-agent: {sub_agent.name}")
+            self._sub_agents.append(sub_agent)
+        return self
 
     def with_mcp_servers(self, mcp_configs: list[BaseMCPConfig]) -> Self:
         """Registers multiple MCP servers to the agent's toolset via the internal MCPToolsetBuilder.
@@ -101,6 +121,23 @@ class AgentBuilder:
             self._skills.append(skill)
         return self
 
+    def with_output_key(self, key: str) -> Self:
+        """Persists the agent's final text response to session state under the given key.
+
+        Using output_key gives the sub-agent memory: subsequent turns can read
+        the prior result from state, enabling follow-up questions to reference
+        earlier research without repeating discovery steps.
+
+        Args:
+            key: str -> Session state key under which the agent's output is stored.
+
+        Returns:
+            Self -> The builder instance for fluent chaining.
+        """
+        logger.info(f"Setting output_key: {key}")
+        self._output_key = key
+        return self
+
     def with_before_agent_callback(self, callback: Callable) -> Self:
         """Sets the before_agent_callback for the agent.
 
@@ -114,12 +151,22 @@ class AgentBuilder:
         self._before_callback = callback
         return self
 
-    def build(self) -> Agent:
+    def build(self, enable_artifact_rendering: bool = True) -> Agent:
         """Assembles and returns the fully configured ADK Agent from all registered tools and settings.
+
+        Specialists using sub_agents= delegation run in the same invocation context,
+        so their after_agent_callbacks and OAuth events propagate correctly to the user.
+        Set enable_artifact_rendering=False only for agents that never produce file_data
+        output (e.g., ingestion-only agents) to skip unnecessary callback overhead.
+
+        Args:
+            enable_artifact_rendering: bool -> When True (default), registers
+                render_pending_artifacts as the after_agent_callback.
 
         Returns:
             Agent -> The executable agent instance.
         """
+        after_callback = render_pending_artifacts if enable_artifact_rendering else None
         return Agent(
             model=Gemini(
                 model_name=self.agent_config.MODEL_NAME,
@@ -155,10 +202,13 @@ class AgentBuilder:
                     function_calling_config=FunctionCallingConfig(mode="AUTO")
                 ),
             ),
+            description=self.agent_config.AGENT_DESCRIPTION or "",
             instruction=self.agent_config.AGENT_INSTRUCTION,
+            output_key=self._output_key,
             tools=self._consolidate_tools(),
+            sub_agents=self._sub_agents,
             before_agent_callback=self._before_callback,
-            after_agent_callback=render_pending_artifacts,
+            after_agent_callback=after_callback,
             planner=BuiltInPlanner(
                 thinking_config=ThinkingConfig(
                     thinking_budget=self.agent_config.THINKING_BUDGET,

--- a/agent/core_agent/builder/app_builder.py
+++ b/agent/core_agent/builder/app_builder.py
@@ -7,7 +7,7 @@ from google.adk.plugins.save_files_as_artifacts_plugin import SaveFilesAsArtifac
 from loguru import logger
 from vertexai.agent_engines import AdkApp
 
-from ..config import AgentConfig, GCPConfig
+from ..config import BaseAgentConfig, GCPConfig
 from ..plugins.ingestion.plugin import GeminiEnterpriseFileIngestionPlugin
 from ..artifact_management.service import StorageService
 
@@ -19,14 +19,14 @@ class AppBuilder:
         self,
         agent: BaseAgent,
         gcp_config: GCPConfig,
-        agent_config: AgentConfig,
+        agent_config: BaseAgentConfig,
     ) -> None:
         """Initializes the AppBuilder with required configurations and the root agent.
 
         Args:
             agent: BaseAgent -> The root ADK agent instance.
             gcp_config: GCPConfig -> Google Cloud Platform project settings.
-            agent_config: AgentConfig -> Core agent and application settings.
+            agent_config: BaseAgentConfig -> Core agent and application settings.
         """
         self.agent = agent
         self.gcp_config = gcp_config

--- a/agent/core_agent/callbacks/ingestion_status.py
+++ b/agent/core_agent/callbacks/ingestion_status.py
@@ -4,7 +4,7 @@ from google.adk.events.event import Event
 from google.genai import types
 from loguru import logger
 
-from ..config import AGENT_CONFIG
+from ..config import INGESTION_AGENT_CONFIG as AGENT_CONFIG
 from ..security import get_id_token
 from ..tools.kb_tools import PENDING_INGESTIONS_KEY
 

--- a/agent/core_agent/config/__init__.py
+++ b/agent/core_agent/config/__init__.py
@@ -1,8 +1,13 @@
 from .agent_settings import (
-    AGENT_CONFIG,
     GCP_CONFIG,
     GOOGLE_AUTH_CONFIG,
-    AgentConfig,
+    COORDINATOR_CONFIG,
+    RESEARCH_AGENT_CONFIG,
+    INGESTION_AGENT_CONFIG,
+    BaseAgentConfig,
+    CoordinatorConfig,
+    ResearchAgentConfig,
+    IngestionAgentConfig,
     GCPConfig,
     GoogleAuthConfig,
 )
@@ -19,7 +24,10 @@ from .mcp_settings import (
 )
 
 __all__ = [
-    "AgentConfig",
+    "BaseAgentConfig",
+    "CoordinatorConfig",
+    "ResearchAgentConfig",
+    "IngestionAgentConfig",
     "GCPConfig",
     "GoogleAuthConfig",
     "BaseMCPConfig",
@@ -28,7 +36,9 @@ __all__ = [
     "DriveMCPConfig",
     "GCSMCPConfig",
     "GCP_CONFIG",
-    "AGENT_CONFIG",
+    "COORDINATOR_CONFIG",
+    "RESEARCH_AGENT_CONFIG",
+    "INGESTION_AGENT_CONFIG",
     "GOOGLE_AUTH_CONFIG",
     "BIGQUERY_MCP_CONFIG",
     "DRIVE_MCP_CONFIG",

--- a/agent/core_agent/config/agent_settings.py
+++ b/agent/core_agent/config/agent_settings.py
@@ -2,6 +2,17 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import AliasChoices, Field
 from typing import Annotated, Optional
 
+_SHARED_AGENT_RULES = """
+            ### LANGUAGE RULE
+            Always respond in the exact same language the user used in their current message. If the user writes in Spanish, respond in Spanish. If the user writes in English, respond in English. Never mix languages within a single response. The only exception is proper nouns such as project names, filenames, company names, or other identifiers that exist in another language — those must be referenced exactly as they appear in the source.
+
+            ### TOOL FAILURE HANDLING
+            If a tool returns an error or an unexpected result, do NOT stop or report the failure immediately. Instead:
+            1. Read the error message carefully to identify the root cause (wrong parameter value, missing field, invalid format, etc.).
+            2. Correct the parameters based on what the error indicates and retry the tool call once.
+            3. Only report the failure to the user if the retry also fails.
+"""
+
 
 class GCPConfig(BaseSettings):
     """Holds configuration values for GCP services, enabling future cloud provider portability."""
@@ -176,9 +187,9 @@ class CoordinatorConfig(BaseAgentConfig):
     AGENT_INSTRUCTION: Annotated[
         str,
         Field(
-            default="""
+            default=f"""
             You are the **Coordinator Agent**, the primary interface for the user. Your job is to analyze the user's request and efficiently route it.
-
+{_SHARED_AGENT_RULES}
             ### OPERATIONAL GUIDELINES
             1. **Small Talk & General Inquiries**: If the user says "Hello", "Thanks", or asks a general non-technical question, answer directly. DO NOT delegate to any specialist.
             2. **Capabilities Questions**: If the user asks what you can do, what you are, or how you can help, respond using ONLY the user-facing capabilities listed in the ### CAPABILITIES section below. Do not mention internal routing, sub-agents, or technical architecture.
@@ -227,9 +238,9 @@ class ResearchAgentConfig(BaseAgentConfig):
     AGENT_INSTRUCTION: Annotated[
         str,
         Field(
-            default="""
+            default=f"""
             You are a **Senior Research Consultant**, specialized in high-precision data discovery and corporate intelligence.
-
+{_SHARED_AGENT_RULES}
             ### SKILL ROUTING
             Before starting any task, load the appropriate skill and follow its protocol exactly:
             - **Research, knowledge discovery, EKB queries, document search, or project/company intelligence** → load the `knowledge-discovery` skill.
@@ -245,6 +256,14 @@ class ResearchAgentConfig(BaseAgentConfig):
             - **Time Constraint**: Do NOT call `get_current_time` if already called in a previous turn — use the timestamp from your history.
             - **Deep-Dive Limit**: In escalation levels, select ONLY the top 2 most relevant documents to read.
             - **Parallel First**: Prefer parallel tool calls in discovery phases to minimize sequential turns.
+
+            ### FOLLOW-UP QUESTION HANDLING
+            When the user asks a follow-up question:
+            1. **Check context first**: Scan the current conversation history for data already retrieved that directly answers the question. If the answer is clearly present, respond from context without calling any tools.
+            2. **Do not settle for absence**: If the answer is not found in the existing context, do NOT respond with "I don't have that information" or similar. Instead, take one of the following actions — in this order:
+               a. If files were already discovered in the current session (Drive, GCS, or other sources) that could plausibly contain the answer, read them using `get_file_text` or `import_gcs_to_artifact`.
+               b. If no such files exist or reading them does not yield the answer, re-execute the `knowledge-discovery` skill targeting the specific gap identified in the follow-up.
+            3. **Never fabricate**: If after active retrieval the information is still not found, state it explicitly and offer to extend the search.
 
             ### SEARCH OPTIMIZATION PROTOCOL
             1. **Targeted Source First**: If the user's request identifies a specific data source, file, or location (e.g. "the Drive document named X", "in BigQuery table Y", "the GCS file at Z"), query that source directly without running the full skill discovery protocol. If it returns results, answer from those. If it returns nothing, load the `knowledge-discovery` skill and run the full protocol.
@@ -284,9 +303,9 @@ class IngestionAgentConfig(BaseAgentConfig):
     AGENT_INSTRUCTION: Annotated[
         str,
         Field(
-            default="""
+            default=f"""
             You are the **EKB Ingestion Specialist**. Your sole responsibility is to trigger knowledge base pipelines and check their execution status.
-            
+{_SHARED_AGENT_RULES}
             ### OPERATIONAL GUIDELINES
             1. When asked to ingest a file, use the appropriate tools to trigger the EKB ingestion pipeline.
             2. When asked to check ingestion status, poll the status using the provided tools.

--- a/agent/core_agent/config/agent_settings.py
+++ b/agent/core_agent/config/agent_settings.py
@@ -44,8 +44,8 @@ class GCPConfig(BaseSettings):
     ]
 
 
-class AgentConfig(BaseSettings):
-    """Holds configuration values for the ADK agent: model, generation, retry, and system prompt."""
+class BaseAgentConfig(BaseSettings):
+    """Holds base configuration values for the ADK agent: model, generation, and retry settings."""
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -54,6 +54,13 @@ class AgentConfig(BaseSettings):
         validate_assignment=True,
     )
 
+    AGENT_DESCRIPTION: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Short description of the agent's role, used as the AgentTool function declaration description when this agent is mounted as a sub-agent.",
+        ),
+    ]
     MODEL_NAME: Annotated[
         str,
         Field(
@@ -135,13 +142,6 @@ class AgentConfig(BaseSettings):
             description="Maximum delay in seconds to retry the request in case of failure.",
         ),
     ]
-    AGENT_NAME: Annotated[
-        str,
-        Field(
-            default="core_agent",
-            description="Name of the agent",
-        ),
-    ]
     EKB_PIPELINE_URL: Annotated[
         str,
         Field(
@@ -162,6 +162,54 @@ class AgentConfig(BaseSettings):
         Field(
             default=-1,
             description="Indicates the thinking budget in tokens. 0 is DISABLED. -1 is AUTOMATIC. The default values and allowed ranges are model dependent.",
+        ),
+    ]
+
+
+class CoordinatorConfig(BaseAgentConfig):
+    """Configuration for the Coordinator Agent."""
+
+    AGENT_NAME: Annotated[
+        str,
+        Field(default="core_agent", description="Name of the coordinator agent"),
+    ]
+    AGENT_INSTRUCTION: Annotated[
+        str,
+        Field(
+            default="""
+            You are the **Coordinator Agent**, the primary interface for the user. Your job is to analyze the user's request and efficiently route it.
+
+            ### OPERATIONAL GUIDELINES
+            1. **Small Talk & General Inquiries**: If the user says "Hello", "Thanks", or asks a general non-technical question, answer directly. DO NOT delegate to any specialist.
+            2. **File Uploads & Delegation**: If the user uploads a file and asks a complex question about it, use `get_artifact_uri` to retrieve its GCS URI. Pass this URI explicitly when delegating to the `research_specialist` so they can analyze it.
+            3. **Deep Research & Meetings**: If the user asks for meeting summaries, deep research, or specific document searches, delegate to the `research_specialist`.
+            4. **Ingestion & Status**: If the user wants to ingest a file or check an ingestion status, delegate to the `ingestion_specialist`.
+            5. **Response Synthesis**: When a specialist returns a result, present it clearly to the user without adding unnecessary fluff.
+            """,
+            description="Agent's System Prompt",
+        ),
+    ]
+
+
+class ResearchAgentConfig(BaseAgentConfig):
+    """Configuration for the Research and Meeting Specialist Agent."""
+
+    AGENT_NAME: Annotated[
+        str,
+        Field(
+            default="research_specialist", description="Name of the research specialist"
+        ),
+    ]
+    AGENT_DESCRIPTION: Annotated[
+        Optional[str],
+        Field(
+            default=(
+                "Retrieves and synthesizes organizational knowledge from the Enterprise "
+                "Knowledge Base (EKB), BigQuery, Google Drive, Google Calendar, and GCS. "
+                "Use for meeting summaries, document discovery, company or project research, "
+                "and any multi-hop data queries that require cross-referencing multiple sources."
+            ),
+            description="AgentTool description exposed to the Coordinator for routing decisions.",
         ),
     ]
     AGENT_INSTRUCTION: Annotated[
@@ -271,6 +319,43 @@ If high-level summaries or metadata are insufficient for a comprehensive answer,
     ]
 
 
+class IngestionAgentConfig(BaseAgentConfig):
+    """Configuration for the EKB Ingestion Specialist Agent."""
+
+    AGENT_NAME: Annotated[
+        str,
+        Field(
+            default="ingestion_specialist",
+            description="Name of the ingestion specialist",
+        ),
+    ]
+    AGENT_DESCRIPTION: Annotated[
+        Optional[str],
+        Field(
+            default=(
+                "Triggers and monitors the Enterprise Knowledge Base (EKB) document ingestion "
+                "pipeline. Use when the user wants to ingest a new file into the knowledge base "
+                "or check the status of an existing ingestion job."
+            ),
+            description="AgentTool description exposed to the Coordinator for routing decisions.",
+        ),
+    ]
+    AGENT_INSTRUCTION: Annotated[
+        str,
+        Field(
+            default="""
+            You are the **EKB Ingestion Specialist**. Your sole responsibility is to trigger knowledge base pipelines and check their execution status.
+            
+            ### OPERATIONAL GUIDELINES
+            1. When asked to ingest a file, use the appropriate tools to trigger the EKB ingestion pipeline.
+            2. When asked to check ingestion status, poll the status using the provided tools.
+            3. Report the result back concisely to the Coordinator.
+            """,
+            description="Agent's System Prompt",
+        ),
+    ]
+
+
 class GoogleAuthConfig(BaseSettings):
     """Holds shared Google OAuth 2.0 credentials used across all MCP server connections."""
 
@@ -319,6 +404,9 @@ class GoogleAuthConfig(BaseSettings):
 
 
 # Global configuration instances
+# Global configuration instances
 GCP_CONFIG = GCPConfig()
-AGENT_CONFIG = AgentConfig()
+COORDINATOR_CONFIG = CoordinatorConfig()
+RESEARCH_AGENT_CONFIG = ResearchAgentConfig()
+INGESTION_AGENT_CONFIG = IngestionAgentConfig()
 GOOGLE_AUTH_CONFIG = GoogleAuthConfig()

--- a/agent/core_agent/config/agent_settings.py
+++ b/agent/core_agent/config/agent_settings.py
@@ -58,7 +58,7 @@ class BaseAgentConfig(BaseSettings):
         Optional[str],
         Field(
             default=None,
-            description="Short description of the agent's role, used as the AgentTool function declaration description when this agent is mounted as a sub-agent.",
+            description="Short description of the agent's role, passed to Agent(description=) and used by the coordinator LLM to identify which specialist to transfer to.",
         ),
     ]
     MODEL_NAME: Annotated[
@@ -209,7 +209,7 @@ class ResearchAgentConfig(BaseAgentConfig):
                 "Use for meeting summaries, document discovery, company or project research, "
                 "and any multi-hop data queries that require cross-referencing multiple sources."
             ),
-            description="AgentTool description exposed to the Coordinator for routing decisions.",
+            description="Agent description used by the coordinator LLM for sub_agents= routing decisions.",
         ),
     ]
     AGENT_INSTRUCTION: Annotated[
@@ -337,7 +337,7 @@ class IngestionAgentConfig(BaseAgentConfig):
                 "pipeline. Use when the user wants to ingest a new file into the knowledge base "
                 "or check the status of an existing ingestion job."
             ),
-            description="AgentTool description exposed to the Coordinator for routing decisions.",
+            description="Agent description used by the coordinator LLM for sub_agents= routing decisions.",
         ),
     ]
     AGENT_INSTRUCTION: Annotated[

--- a/agent/core_agent/config/agent_settings.py
+++ b/agent/core_agent/config/agent_settings.py
@@ -181,10 +181,22 @@ class CoordinatorConfig(BaseAgentConfig):
 
             ### OPERATIONAL GUIDELINES
             1. **Small Talk & General Inquiries**: If the user says "Hello", "Thanks", or asks a general non-technical question, answer directly. DO NOT delegate to any specialist.
-            2. **File Uploads & Delegation**: If the user uploads a file and asks a complex question about it, use `get_artifact_uri` to retrieve its GCS URI. Pass this URI explicitly when delegating to the `research_specialist` so they can analyze it.
-            3. **Deep Research & Meetings**: If the user asks for meeting summaries, deep research, or specific document searches, delegate to the `research_specialist`.
-            4. **Ingestion & Status**: If the user wants to ingest a file or check an ingestion status, delegate to the `ingestion_specialist`.
-            5. **Response Synthesis**: When a specialist returns a result, present it clearly to the user without adding unnecessary fluff.
+            2. **Capabilities Questions**: If the user asks what you can do, what you are, or how you can help, respond using ONLY the user-facing capabilities listed in the ### CAPABILITIES section below. Do not mention internal routing, sub-agents, or technical architecture.
+            3. **File Uploads & Delegation**: If the user uploads a file and asks a complex question about it, use `get_artifact_uri` to retrieve its GCS URI. Pass this URI explicitly when delegating to the `research_specialist` so they can analyze it.
+            4. **Deep Research & Meetings**: If the user asks for meeting summaries, deep research, or specific document searches, delegate to the `research_specialist`.
+            5. **Ingestion & Status**: If the user wants to ingest a file or check an ingestion status, delegate to the `ingestion_specialist`.
+            6. **Response Synthesis**: When a specialist returns a result, present it clearly to the user without adding unnecessary fluff.
+
+            ### CAPABILITIES
+            When asked about your capabilities, describe what you can do for the user in plain language:
+            - **Break information silos**: Retrieve and correlate information scattered across multiple organizational data sources — the Enterprise Knowledge Base (EKB), Google Drive, Google Calendar, BigQuery, and Google Cloud Storage — and present it as a unified, coherent answer.
+            - **Research & knowledge discovery**: Search for documents, projects, companies, technologies, and people across all connected data sources. Cross-reference findings to surface relationships and context the user may not have known to look for.
+            - **Meeting summaries**: Generate structured meeting summary documents from transcripts or meeting notes stored in Drive, following a standard template, and save them back to Drive automatically.
+            - **Calendar awareness**: Retrieve upcoming and past calendar events, identify relevant meetings for a given project or topic, and surface key context from meeting attachments and linked documents.
+            - **Enterprise Knowledge Base (EKB) ingestion**: Upload a PDF document into the EKB so it becomes searchable by the whole organization. The agent handles classification, metadata tagging, deduplication, and pipeline triggering — just provide the file and answer a few questions.
+            - **Ingestion status tracking**: Check the processing status of any previously submitted EKB ingestion job by its job ID.
+            - **File analysis**: If you upload a file directly in the conversation, the agent can analyze its content and combine it with information retrieved from other data sources.
+            - **Your data, your permissions**: The agent never accesses data you are not authorized to see. Every request to Google Drive, Calendar, BigQuery, and GCS is made using your own Google OAuth credentials — the same permissions your Google account has. If you cannot open a file in Drive, the agent cannot read it either.
             """,
             description="Agent's System Prompt",
         ),
@@ -216,103 +228,32 @@ class ResearchAgentConfig(BaseAgentConfig):
         str,
         Field(
             default="""
-            You are a **Senior Research Consultant**, an expert in high-precision data discovery and corporate intelligence. Your execution is governed by these operational standards:
+            You are a **Senior Research Consultant**, specialized in high-precision data discovery and corporate intelligence.
 
-            ### OPERATIONAL GUIDELINES
-
-            1. **Tool Integrity & Schema Compliance**:
-               - Verify tool schemas before execution. Strictly follow parameter structures (nesting under `request` if required).
-               - Fail Fast: Immediately correct and retry if a schema error occurs.
-
-            2. **State Awareness & Persistence**:
-               - **Internal Memory**: Remember table names, schemas, and parameters (IDs, filter values) for the session. Use this to speed up subsequent queries and avoid redundant discovery. Never guess column names.
-
-            3. **Relational Discovery & Contextual Inference**:
-               - **Cross-Domain Pivot**: When asked about a Company, Project, or Tech Stack, you MUST proactively search for related entities:
-                   - **Mapping**: If "Company A" is mentioned, find the "Project A" they are working on via EKB.
-                   - **Implicit Calendar Match**: Once a project or company is identified, retrieve broad Calendar events through TWO separate requests (Past and Future) using `list_calendar_events` with a strict 1-month window each (Current Date ± 1 Month).
-                   - **Temporal Execution**: 
-                       1. **Past Window**: [Current Date - 1 Month] to [Current Date], sorted `desc` (nearest events first).
-                       2. **Future Window**: [Current Date] to [Current Date + 1 Month], sorted `asc` (nearest events first).
-                   - **Filter Rule**: For these initial requests, you MUST use ONLY date filters and `sort_order`. Map these results to your identified entities based on the relational anchors established in previous discovery phases.
-                   - **Deep Relationship Fallback**: If no direct relations are found, you MUST attempt to identify shared themes, technologies, or generalities in EKB metadata (descriptions, summaries) or via semantic search to 
-                       establish high-fidelity implicit links before excluding information.
-                   - **Completeness**: Always return the project details, the companies involved, and the relevant temporal context (past/future meetings) that connects these entities.
-
-            4. **Mandatory Calendar Discovery Protocol**:
-               - **Mandatory Baseline**: Whenever you are asked about a Project, Company, Tech Stack, or general status, you MUST perform TWO separate broad requests (Past and Future) to establish a temporal baseline.
-               - **Constraint**: You are ONLY allowed to use a specific `query` parameter if the user provides a precise, non-entity-based search (e.g., "Find the 'Engineering Sync' on May 5th"). For all other cases, you MUST follow the 1-month broad search.
-               - **1-Month Window**: Each request must cover exactly 1 month from the current date (Current Date ± 1 Month).
-               - **Parameter Restriction**: In these discovery requests, you MUST NOT include any parameters other than date filters and `sort_order`. 
-               - **Nearest Events Focus**: Use `sort_order="desc"` for the Past window and `sort_order="asc"` for the Future window to prioritize nearest events.
-               - **Internal Relational Mapping**: Retrieve ALL events in the window first, then internally identify those related to projects or companies identified via relational discovery & contextual inference.
-               - **Document Evaluation**: Analyze attachments or references in the retrieved events to synthesize collaborative context.
-
-            5. **Data Hierarchy & GCS Priority**:
-               - **EKB, Calendar, and GCS** are top-priority sources for organizational truth.
-               - **GCS Persistence**: Since GCS stores the source-of-truth files for EKB, you MUST save and prioritize `gcs_uri` references. Use them for full-text ingestion to resolve deep technical inquiries.
+            ### SKILL ROUTING
+            Before starting any task, load the appropriate skill and follow its protocol exactly:
+            - **Research, knowledge discovery, EKB queries, document search, or project/company intelligence** → load the `knowledge-discovery` skill.
+            - **Meeting summaries or creating a formatted summary document from a transcript or meeting file** → load the `meeting-summary` skill.
 
             ### CORE PRINCIPLES
-
-            1. **Strict Factuality & No Hallucination**:
-               - NEVER invent information. If data is not found, state it clearly: "I could not find information regarding X; perhaps more specific details could help."
-            2. **Clean, Human-Centric Output**:
-               - NEVER show internal identifiers (IDs, hashes, raw `gcs_uri`, or technical UUIDs). Focus on human-readable names for files and projects.
-            3. **Attribution & Transparency**:
-               - For every piece of information, include a reference section.
-               - **STRICT REFERENCE RULE**: Include ONLY the specific files and events from which data was explicitly extracted. NEVER include broad discovery results or unused tool outputs in the reference section.
-               - **Format**:
-                 - **Source**: [EKB, Calendar, Drive, BQ, GCS, etc.]
-                 - **Filename/Event**: [Human-readable Name or Meeting Title]
-                 - **Owner/Author**: [Author email or document metadata]
-                 - **Last Update**: [Timestamp or Creation Date if update is missing]
-
-            ### DISCOVERY & ESCALATION PROTOCOL
-            - **Level 1: EKB/GCS Deep-Dive**: Prioritize reading full GCS content from EKB.
-            - **Level 2: Calendar Deep-Dive**: Evaluate and read documents/notes attached to or mentioned in relevant meetings.
-            - **Level 3: Drive Deep-Dive**: Search and read relevant documents in Google Drive.
-            - **Level 4: Conclusion**: If all fail, state that the info was not found. Do not hallucinate.
-
-            ### Phase 3: Synthesis & Targeted Deep Dive (Escalation Path)
-If high-level summaries or metadata are insufficient for a comprehensive answer, follow this strict escalation order:
-
-1.  **Level 1: EKB Deep-Dive (GCS)**:
-    -   Use `read_object` to retrieve metadata (MIME type) and then `import_gcs_to_artifact` to analyze the full content of high-relevance `gcs_uri` references found in Phase 1 and 2.
-    -   Prioritize technical specifications, architecture diagrams, and project charters stored in EKB.
-2.  **Level 2: Drive Deep-Dive**:
-    -   If Level 1 is insufficient, use `get_file_text` to search and read the full content of relevant Google Drive documents found in Phase 2.
-    -   Focus on collaborative docs, meeting notes, and spreadsheets that might contain the specific missing detail.
-3.  **Level 3: Final Conclusion**:
-    -   If the information is not found after both deep-dives, concisely state that the specific data was not found in the available Enterprise Knowledge Base or personal Drive. Do not hallucinate or guess.
-
-### MANDATORY OUTPUT STRUCTURE
--   **Upcoming Meetings Extraction**: Identify and format all relevant meetings occurring after the current date found during Phase 2 discovery.
--   **Synthesis & Output**: 
-    -   Cross-correlate findings into a unified narrative, resolving contradictions and deduplicating information.
-    -   **MANDATORY**: For broad research requests, format the final response strictly according to the **OUTPUT STRUCTURE** defined in the System Prompt. For specific questions, be concise but **ALWAYS** include the **## References** section.
-
-            - **Summary**: 1-2 paragraphs giving a brief summary of the data requested and providing context.
-            - **## Key Points**: Bullet points including important dates, decisions, and major findings.
-            - **## Stakeholders**: List of people involved or who to contact for further information.
-            - **## Upcoming Meetings**: List relevant meetings found in the near future, including Date, Time, Participants, and Purpose.
-            - **## References**: Detailed list as specified in the Attribution section.
-
-            *Note: If no information is found for a specific section (e.g., no upcoming meetings), state "No information found" or omit the section to keep the response concise.*
-
-            ### DISCOVERY & ESCALATION PROTOCOL
-            - **Level 1: EKB/GCS Deep-Dive**: If initial metadata is insufficient, prioritize reading the full content of GCS files from the Enterprise Knowledge Base.
-            - **Level 2: Drive Deep-Dive**: If Level 1 fails, search and read relevant documents in Google Drive.
-            - **Level 3: Conclusion**: If both fail, state that the info was not found. Do not hallucinate.
+            1. **Strict Factuality**: NEVER invent information. If data is not found, state it clearly: "I could not find information regarding X."
+            2. **Clean Output**: NEVER expose internal identifiers (IDs, hashes, raw GCS URIs, UUIDs). Use human-readable names only.
+            3. **Attribution**: Every response must close with a `## References` Markdown table (columns: Source, Filename, Owner, Created at / Last Update). Include ONLY sources from which data was explicitly extracted. Format is defined in the `knowledge-discovery` skill.
 
             ### CRITICAL EFFICIENCY RULES
-            - **No Redundancy**: NEVER call the same tool with the same parameters. If a search failed, change the keywords or move to the next Level.
-            - **Time Constraint**: DO NOT call `get_current_time` if you already called it in a previous turn. Use the timestamp from your history.
-            - **Deep-Dive Limit**: In Level 1 and 2, select ONLY the top 2 most relevant documents to read. Do not attempt to read everything.
-            - **Parallel First**: Prefer parallel calls in Phase 2 to avoid multiple sequential turns.
+            - **No Redundancy**: NEVER call the same tool with the same parameters in a session.
+            - **Time Constraint**: Do NOT call `get_current_time` if already called in a previous turn — use the timestamp from your history.
+            - **Deep-Dive Limit**: In escalation levels, select ONLY the top 2 most relevant documents to read.
+            - **Parallel First**: Prefer parallel tool calls in discovery phases to minimize sequential turns.
 
-            ### INTERACTION STYLE
-            - **Parallel Initial Research**: For any new or vague topic, start with parallel discovery (EKB + Calendar + BQ Metadata) to maximize context.
-            - **Silent Logic**: Provide results and synthesis only; do not narrate your tool selection process.
+            ### SEARCH OPTIMIZATION PROTOCOL
+            1. **Targeted Source First**: If the user's request identifies a specific data source, file, or location (e.g. "the Drive document named X", "in BigQuery table Y", "the GCS file at Z"), query that source directly without running the full skill discovery protocol. If it returns results, answer from those. If it returns nothing, load the `knowledge-discovery` skill and run the full protocol.
+            2. **Broad-First, Then Narrow**: Always start with the widest possible query (maximum date window, fewest filters). Narrow parameters only when a broad result is insufficient.
+            3. **Per-Source Iteration Cap**: After the initial broad query, up to **3 additional targeted attempts** per data source per turn (tighten keywords, adjust date ranges, add filters). After 3 failures on a single source, stop and move on.
+            4. **Escalate to User**: If data is still not found after all attempts, ask the user for more context — alternative names, the correct data source, date range, or other identifiers. Do not hallucinate or keep retrying.
+
+            ### GCS FILE READING RULE
+            Storing a `gcs_uri` reference found in metadata is always fine. This rule applies only when the agent actively decides to read a file's full content from GCS. In that case, ALWAYS load it via `import_gcs_to_artifact` followed by `load_artifacts` to read it as a multimodal artifact. NEVER download raw bytes or extract text directly from GCS.
             """,
             description="Agent's System Prompt",
         ),

--- a/agent/core_agent/tools/kb_tools.py
+++ b/agent/core_agent/tools/kb_tools.py
@@ -5,7 +5,7 @@ from google.genai import types
 from loguru import logger
 from typing_extensions import override
 
-from ..config import AGENT_CONFIG
+from ..config import INGESTION_AGENT_CONFIG as AGENT_CONFIG
 from ..security import get_id_token
 from .kb_schemas import (
     TriggerEKBPipelineRequest,

--- a/agent/skills/kb-file-ingestion/SKILL.md
+++ b/agent/skills/kb-file-ingestion/SKILL.md
@@ -18,10 +18,12 @@ or similar requests.
 
 ## Progress Tracker
 Maintain this state throughout the interaction:
-- [ ] Step 1: Identify and verify session artifact
-- [ ] Step 2: Collect metadata and validate project (Deduplication)
-- [ ] Step 3: Relocate file and stamp metadata
-- [ ] Step 4: Trigger EKB Pipeline
+- [ ] Step 1: Identify and validate all uploaded PDF files
+- [ ] Step 2a: Collect shared metadata (single message for all files)
+- [ ] Step 2b: Semantic project validation + deduplication check (per file)
+- [ ] Step 2c: Present confirmation table → handle per-file overrides → await explicit user confirmation
+- [ ] Step 3: Relocate and stamp metadata (parallel — all files simultaneously)
+- [ ] Step 4: Trigger EKB pipeline (parallel — all files simultaneously) + consolidated final summary
 
 ## Gotchas
 - **GCS URIs**: The agent landing zone is always `gs://ai_agent_landing_zone/`. 
@@ -35,46 +37,74 @@ Maintain this state throughout the interaction:
 ### Step 1: Identify and Validate the File
 1.  Use the `get_artifact_uri` tool to find the URI of the file the user just uploaded.
 2.  **Validation**:
-    - **File Type**: Ensure the file is a **PDF**. If it is not a PDF (e.g., `.docx`, `.txt`), inform the user: "Endava's Knowledge Base only accepts PDF documents. Please convert your file to PDF and upload it again to continue."
-    - **Multi-file**: If multiple PDF files exist, ask: "I see several PDFs ([List]). Which one should I ingest?"
-    - **Missing**: If no PDF file is found, ask: "Please upload the PDF document you'd like to add to the knowledge base."
+    - **File Type**: Ensure every detected file is a **PDF**. For any non-PDF (e.g. `.docx`, `.txt`), inform the user: "Endava's Knowledge Base only accepts PDF documents. Please convert `<filename>` to PDF and upload it again."
+    - **Multi-file**: If multiple PDF files exist, list them all and proceed with the full batch — do NOT ask the user to pick one.
+    - **Missing**: If no PDF file is found, ask: "Please upload the PDF document(s) you'd like to add to the knowledge base."
 
-### Step 2: Information Gathering & Validation
-To minimize turns, **ALWAYS** ask for all necessary information in a single bulleted message immediately after Step 1:
+### Step 2: Information Gathering, Validation & Confirmation
 
-"Before storing the file, please provide me the following information:
-- **project the file belongs to**:
-- **domain**: (Options: `IT, Finance, HR, Sales, Executives, Legal, Operations`)
-- **trust-level**: (Options: 
-    - `Published`: Verified, official document that is currently valid and ready for company-wide consumption.
-    - `WIP` (Work In Progress): Draft or evolving document that is still being refined; use this for active projects.
-    - `Archived`: Historical reference that is no longer active or valid, but should be kept for context or audit purposes.)
-- **PII Status**: Does this document contain any Personally Identifiable Information (Names, emails, IDs)?"
+#### 2a — Metadata Collection
 
-**Once the user provides the information, perform the following in sequence:**
+**Single file**: Ask for all metadata in one message immediately after Step 1:
+
+> "Before publishing the file to the EKB, please provide me the following information:
+> - **Project the file belongs to**:
+> - **Domain**: (`IT` / `Finance` / `HR` / `Sales` / `Executives` / `Legal` / `Operations`)
+> - **Trust-level**: (`Published` — verified & ready for company-wide use | `WIP` — draft still being refined | `Archived` — historical reference, no longer active)
+> - **PII Status**: Does this document contain any Personally Identifiable Information (names, emails, IDs)?"
+
+**Multiple files (Batch Mode)**: List all detected filenames, then ask for shared metadata in one message:
+
+> "Before publishing those files to the EKB, please provide me the following information:
+> - **Files detected**: `<file1.pdf>`, `<file2.pdf>`, … *(list all)*
+> - **Project the files belong to**:
+> - **Domain**: (`IT` / `Finance` / `HR` / `Sales` / `Executives` / `Legal` / `Operations`)
+> - **Trust-level**: (`Published` | `WIP` | `Archived`)
+> - **PII Status**: Do any of these documents contain Personally Identifiable Information (names, emails, IDs)?"
+
+#### 2b — Validation (run for every file)
+
+Once the user provides the information, perform the following in sequence:
 
 1.  **Semantic Project Validation**: Use `ekb_semantic_search(query='<user_input_project_name>')`.
     - If a high-confidence match exists, proceed with that `project_id`.
     - If ambiguous, ask: "I found existing projects that might match: [List]. Is it one of these?"
-2.  **Deduplication Check**: If the project exists, check for duplicate filenames and retrieve their existing metadata:
+2.  **Deduplication Check**: For each file, check for duplicate filenames in the confirmed project:
     ```sql
     SELECT filename, domain, classification_tier 
     FROM `knowledge_base.documents_metadata` 
     WHERE project_id = '<confirmed_project>' AND lower(filename) = lower('<uploaded_filename>')
       AND latest = TRUE
     ```
-    - If found, ask: "A version of '<filename>' already exists. Should I replace it or would you like to rename this file?"
-    - **MANDATORY**: If the user chooses to **REPLACE** the file, you MUST reuse the `domain` and `classification_tier` retrieved from the existing record for the new ingestion.
-3.  **Final Summary**: Confirm the final metadata values with the user before proceeding to Step 3.
+    - If a duplicate is found, ask: "A version of `<filename>` already exists. Should I replace it or would you like to rename this file?"
+    - **MANDATORY**: If the user chooses to **REPLACE**, reuse the `domain` and `classification_tier` from the existing record for that file.
 
-### Step 3: Relocation & Stamping
+#### 2c — Confirmation & Per-File Override
+
+After validation, present a summary table of the full ingestion plan:
+
+| File | Project | Domain | Trust-level | PII |
+|:---:|:---:|:---:|:---:|:---:|
+| `<file1.pdf>` | `<project_id>` | `<domain>` | `<trust-level>` | Yes / No |
+| `<file2.pdf>` | `<project_id>` | `<domain>` | `<trust-level>` | Yes / No |
+
+Then ask *(single file)*:
+> "Does everything look correct? If so, I will proceed with the publishing process or let me know if anything needs to change."
+
+Or *(multiple files)*:
+> "Should I apply these same metadata values to all files? If any file needs a different project, domain, trust-level, or PII status, please specify the filename and the values that differ. Otherwise I will proceed with publishing all files."
+
+- If the user specifies per-file overrides, update the plan for those files, re-display the corrected table, and ask for final confirmation before continuing.
+- Do NOT proceed to Step 3 until the user explicitly confirms.
+
+### Step 3: Relocation & Stamping *(execute in parallel for all files in the confirmed batch)*
 1.  **Move File**: Use `upload_object` (from GCS MCP) to copy the file using these parameters:
-    - `source_gcs_uri`: The URI identified in Step 1.
+    - `source_gcs_uri`: The URI identified in Step 1 for this file.
     - `destination_bucket`: "ag-core-dev-fdx7-kb-landing-zone"
     - `filename`: The confirmed filename.
-    - `path_inside_bucket`: The confirmed `<project_id>`.
+    - `path_inside_bucket`: The confirmed `<project_id>` for this file.
     - **Note**: The relocation process automatically preserves the source metadata.
-2.  **Stamp Metadata**: Use `update_object_metadata` (GCS) to attach the following. This will be **merged** with existing metadata:
+2.  **Stamp Metadata**: Use `update_object_metadata` (GCS) to attach the confirmed metadata for this file. This will be **merged** with existing metadata:
     ```json
     {
       "project": "<project>",
@@ -84,14 +114,17 @@ To minimize turns, **ALWAYS** ask for all necessary information in a single bull
     }
     ```
 
-### Step 4: Trigger Pipeline
-1.  Call `trigger_ekb_pipeline(gcs_uri='<destination_uri_returned_in_Step_3>')`.
-    - **Note**: This MUST be exactly the same URI returned by the `upload_object` tool.
-2.  **Final Confirmation**: Provide the user with a summary using this template:
+### Step 4: Trigger Pipeline *(execute in parallel for all files in the confirmed batch)*
+1.  Call `trigger_ekb_pipeline(gcs_uri='<destination_uri_returned_in_Step_3>')` for each file simultaneously.
+    - **Note**: This MUST be exactly the same URI returned by the `upload_object` tool for that file.
+2.  **Final Confirmation**: After all files have been processed, provide a single consolidated summary:
     ```markdown
-    ### ✅ Ingestion Started
-    - **File**: <filename>
-    - **Project**: <project_id>
-    - **Job ID**: <job_id_from_tool>
-    - **Status**: The document is being processed and will be available in the KB shortly.
+    ### Ingestion Started
+    | File | Project | Job ID | Status |
+    |:---:|:---:|:---:|:---:|
+    | <file1.pdf> | <project_id> | <job_id> | <current job status> |
+    | <file2.pdf> | <project_id> | <job_id> | <current job status> |
+
+    All documents are being processed and will be available in the KB shortly.
     ```
+    For a single file, use the original single-entry format instead of the table.

--- a/agent/skills/knowledge-discovery/SKILL.md
+++ b/agent/skills/knowledge-discovery/SKILL.md
@@ -6,6 +6,14 @@ description: Expert protocol for high-fidelity data retrieval and analysis using
 ## Mandatory Execution Mode
 Trigger this skill for any research task or when the user's query is broad or vague. Use this to establish a factual baseline across all data sources.
 
+## BigQuery Query Protocol
+This protocol applies **every time** you are about to call `execute_query`, regardless of which phase you are in.
+
+1.  **Discover tables** (skip if already done this session for the same dataset): Call `list_tables` to confirm which tables exist inside the target dataset.
+2.  **Fetch and cache schema** (skip if already fetched this session for the same table): Call `get_table_schema` for each table you intend to query. Store the returned field names and types in your working memory — do **not** call `get_table_schema` again for the same table later in the same session.
+3.  **Construct the query**: Build the SQL using only column names confirmed in step 2. Never guess column names.
+4.  **Execute**: Call `execute_query` with the validated query.
+
 ## Discovery Protocol
 
 ### Phase 1: Contextual Anchoring (The Hook)
@@ -32,11 +40,13 @@ Maximize information gathering by querying multiple sources in parallel.
     -   **Relational Mapping**: Once all events in the window are retrieved, perform internal filtering to identify events related to the projects or companies found in Phase 1 (EKB).
     -   **Targeted Follow-up** (only if the broad baseline returns no relevant events): Apply specific parameters — a `query` string using entity names from Phase 1, or keywords extracted directly from the user's original prompt if Phase 1 returned nothing, a wider date window (±2–3 months), or attendee filters. **Maximum 3 additional targeted attempts.** After 3 attempts without a useful result, stop and move to Phase 3.
 2.  **BigQuery (Structural Context)**:
-    -   **MANDATORY**: Query the `documents_metadata` table inside the `knowledge_base` dataset.
+    -   **MANDATORY**: Follow the BigQuery Query Protocol above before querying. Target the `documents_metadata` table inside the `knowledge_base` dataset.
     -   **Data Capture**: Retrieve and store all metadata, especially the **document summary/description**, linked to the identified project, domain, or company.
-3.  **Google Drive (Personal Context)**:
-    -   **Best Practice**: Perform searches using **single keywords** or very short phrases (e.g., search "Alpha" instead of "Project Alpha"). This avoids missing files with naming variations like "Alpha Follow-up" or "Project Continuation - Alpha".
-    -   **Keywords**: Use company names, technologies, stacks, and project names found in Phase 1. If no keywords were found in Phase 1, use the project_name, company name, or any information that the user provided in the prompt that could be used as keywords.
+3.  **Google Drive (Personal Context - Two-Wave Parallel Search)**:
+    -   **Keyword Extraction**: Collect all useful nouns from Phase 1 anchors and the user's original prompt — project names, company names, technologies, people, product names, and other domain-specific terms. **Always exclude intent words like "duration", "status", or "summary"**.
+    -   **Wave 1 — Single-word searches (run in parallel)**: Execute up to 3 `list_files` requests simultaneously, each using a different single keyword (e.g., `"Innovation"`, `"Alpha"`, `"Gemini"`). Prioritize the most distinctive nouns: project name first, then company name, then any other relevant keyword. If no relevant files are found by name, retry with 3 new different single-word keywords. Repeat up to **2 rounds maximum** before moving to Wave 2.
+    -   **Wave 2 — Two-word fallback (run in parallel, only if Wave 1 returns no relevant filenames after all rounds)**: Combine the most relevant single keywords into 2-word phrases (e.g., `"Innovation Inc"`, `"Project Alpha"`) and execute up to 3 `list_files` requests simultaneously, each using a different phrase. If no relevant files are found by name, retry with 3 new different 2-word phrases. Repeat up to **2 rounds maximum**.
+    -   **Exclusion Rule**: Never use intent keywords (e.g., "duration", "project length", "status") in any search. Focus on nouns that likely appear in filenames.
 4.  **GCS (Raw Data Reference)**:
     -   Identify and store specific `gcs_uri` references for high-relevance files found in the metadata.
 
@@ -49,8 +59,11 @@ If high-level summaries or metadata are insufficient for a comprehensive answer,
 2.  **Level 2: Calendar Deep-Dive (Personal Context)**:
     -   Identify any **documents or links** mentioned in the descriptions or attachments of relevant past meetings found in Phase 2.
     -   Search for and read the content of these specific documents (using Drive or GCS tools) to capture meeting decisions, notes, or referenced data.
-3.  **Level 3: Drive Deep-Dive**:
-    -   If the information is still missing, use `get_file_text` to search and read the full content of relevant Google Drive documents found in Phase 2 discovery.
+3.  **Level 3: Drive Iterative Discovery**:
+    -   **Step 1 (Read)**: Use `get_file_text` to read the top 3 most relevant files found in Phase 2.
+    -   **Step 2 (Evaluate)**: If the information is found, stop and synthesize.
+    -   **Step 3 (Pivot & Repeat)**: If not found, extract new keywords from the text read (e.g., project codes, aliases, or stakeholders) and perform a new parallel search (Step 1).
+    -   **Constraint**: Repeat this loop a maximum of 3 times. Ensure each search uses unique keywords to avoid redundant results.
 4.  **Level 4: Relationship Fallback (Implicit Mapping)**:
     -   If direct project/company links are missing, analyze EKB metadata (descriptions, summaries, and tech stacks) for shared technologies, industry themes, or generalities.
     -   Use these broader themes to re-evaluate the broad results found in Phase 2 (Calendar/Drive) to identify high-fidelity implicit relationships.
@@ -60,9 +73,19 @@ If high-level summaries or metadata are insufficient for a comprehensive answer,
     -   Do not continue searching without the user's input. Do not hallucinate.
 
 ### MANDATORY OUTPUT STRUCTURE
-Cross-correlate all findings into a unified narrative before writing the response. Every response MUST follow this exact section order. Omit a section only if genuinely no data exists for it — in that case write `No information found` under that heading, do not skip the heading entirely.
+Before writing the response, classify the question:
+-   **Concise Mode**: the question has a clear, narrow answer (a single fact, name, date, count, status, or yes/no). Use this mode for targeted lookups.
+-   **Full Report Mode**: the answer requires synthesizing information across multiple sources, documents, or time periods. Use this mode for broad or exploratory research.
 
 ---
+
+#### Concise Mode
+Respond directly in plain prose (1–3 sentences). Then append only the `## References` table (see format below). Skip all other sections.
+
+---
+
+#### Full Report Mode
+Cross-correlate all findings into a unified narrative before writing the response. Follow this exact section order. Omit a section only if genuinely no data exists for it — in that case write `No information found` under that heading, do not skip the heading entirely.
 
 **Summary** *(always present)*
 1–2 paragraphs. Brief context of what was found, the topic, and its relevance. No bullet points here.
@@ -91,7 +114,16 @@ If none found: `No recent meetings found for this topic.`
 
 ---
 
-**## References**
+**## Extend Search?** *(include ONLY when Level 5 is reached — all standard sources exhausted with no relevant results)*
+Begin with one sentence stating which sources were searched and what terms were used. Then include this question verbatim:
+
+> "I have searched the Enterprise Knowledge Base, Google Calendar, and Google Drive using the available context and found no matching data. Would you like me to extend the search to your personal GCS buckets or BigQuery tables? If yes, please share the bucket name, path prefix, or table/dataset identifier and I will search there directly."
+
+This section MUST appear after `## References` at Level 5. Omitting it when Level 5 is reached means the task is incomplete.
+
+---
+
+**## References** *(both modes)*
 Markdown table. Include ONLY the files, documents, and events from which data was explicitly extracted to produce this response. NEVER include broad discovery results or unused tool outputs.
 
 | Source | Filename | Owner | Created at / Last Update |
@@ -102,12 +134,3 @@ Markdown table. Include ONLY the files, documents, and events from which data wa
 -   **Filename**: human-readable name or event title. NEVER show raw IDs, hashes, or GCS URIs.
 -   **Owner**: uploader email, document owner, or event organizer. Use `Unknown` if unavailable.
 -   **Created at / Last Update**: `YYYY-MM-DD`. Use `Unknown` if unavailable.
-
----
-
-**## Extend Search?** *(include ONLY when Level 5 is reached — all standard sources exhausted with no relevant results)*
-Begin with one sentence stating which sources were searched and what terms were used. Then include this question verbatim:
-
-> "I have searched the Enterprise Knowledge Base, Google Calendar, and Google Drive using the available context and found no matching data. Would you like me to extend the search to your personal GCS buckets or BigQuery tables? If yes, please share the bucket name, path prefix, or table/dataset identifier and I will search there directly."
-
-This section MUST appear after `## References` at Level 5. Omitting it when Level 5 is reached means the task is incomplete.

--- a/agent/skills/knowledge-discovery/SKILL.md
+++ b/agent/skills/knowledge-discovery/SKILL.md
@@ -34,7 +34,7 @@ Maximize information gathering by querying multiple sources in parallel.
     -   **Data Capture**: Retrieve and store all metadata, especially the **document summary/description**, linked to the identified project, domain, or company.
 3.  **Google Drive (Personal Context)**:
     -   **Best Practice**: Perform searches using **single keywords** or very short phrases (e.g., search "Alpha" instead of "Project Alpha"). This avoids missing files with naming variations like "Alpha Follow-up" or "Project Continuation - Alpha".
-    -   **Keywords**: Use company names, technologies, stacks, and project names found in Phase 1.
+    -   **Keywords**: Use company names, technologies, stacks, and project names found in Phase 1. If no keywords were found in Phase 1, use the project_name, company name, or any information that the user provided in the prompt that could be used as keywords.
 4.  **GCS (Raw Data Reference)**:
     -   Identify and store specific `gcs_uri` references for high-relevance files found in the metadata.
 

--- a/agent/skills/knowledge-discovery/SKILL.md
+++ b/agent/skills/knowledge-discovery/SKILL.md
@@ -18,6 +18,7 @@ Trigger this skill for any research task or when the user's query is broad or va
     -   **People**: `uploader_email` and key stakeholders mentioned in descriptions.
     -   **Locations**: `gcs_uri` (essential for technical deep-dives).
 3.  **Expansion**: If results are narrow, broaden the search using the extracted entities and keywords to find related entries before moving to Phase 2.
+    -   **Zero-Result Fallback**: If `ekb_semantic_search` returns no results at all, do not stop. Extract keywords directly from the user's original prompt (company names, project names, technologies, people, dates) and use those as Phase 2 anchors for Drive and Calendar. Skip the BigQuery `documents_metadata` query in this case — there is no project context to anchor it against.
 
 ### Phase 2: Parallel Context Acquisition (Broad Search)
 Maximize information gathering by querying multiple sources in parallel. 
@@ -29,6 +30,7 @@ Maximize information gathering by querying multiple sources in parallel.
         -   **Request 2 (Future)**: From [Current Date] to [Current Date + 1 Month]. Use `sort_order="asc"` to retrieve the nearest upcoming events.
     -   **MANDATORY RESTRICTION**: In these first two requests, you MUST NOT include any parameters other than date filters and `sort_order`. 
     -   **Relational Mapping**: Once all events in the window are retrieved, perform internal filtering to identify events related to the projects or companies found in Phase 1 (EKB).
+    -   **Targeted Follow-up** (only if the broad baseline returns no relevant events): Apply specific parameters — a `query` string using entity names from Phase 1, or keywords extracted directly from the user's original prompt if Phase 1 returned nothing, a wider date window (±2–3 months), or attendee filters. **Maximum 3 additional targeted attempts.** After 3 attempts without a useful result, stop and move to Phase 3.
 2.  **BigQuery (Structural Context)**:
     -   **MANDATORY**: Query the `documents_metadata` table inside the `knowledge_base` dataset.
     -   **Data Capture**: Retrieve and store all metadata, especially the **document summary/description**, linked to the identified project, domain, or company.
@@ -53,11 +55,59 @@ If high-level summaries or metadata are insufficient for a comprehensive answer,
     -   If direct project/company links are missing, analyze EKB metadata (descriptions, summaries, and tech stacks) for shared technologies, industry themes, or generalities.
     -   Use these broader themes to re-evaluate the broad results found in Phase 2 (Calendar/Drive) to identify high-fidelity implicit relationships.
 5.  **Level 5: Final Conclusion**:
-    -   If the information is not found after all deep-dives (including implicit mapping), concisely state that the specific data was not found in the available Enterprise Knowledge Base or personal Drive. Do not hallucinate or guess.
+    -   Produce the standard output structure with `No information found` under any section where data is missing.
+    -   **MANDATORY**: Your response MUST include the `## Extend Search?` section defined at the end of the MANDATORY OUTPUT STRUCTURE. This section is not optional at Level 5 — if it is missing, the task is incomplete.
+    -   Do not continue searching without the user's input. Do not hallucinate.
 
 ### MANDATORY OUTPUT STRUCTURE
--   **Upcoming Meetings Extraction**: Identify and format all relevant meetings occurring after the current date found during Phase 2 discovery.
--   **Synthesis & Output**: 
-    -   Cross-correlate findings into a unified narrative, resolving contradictions and deduplicating information.
-    -   **STRICT REFERENCE RULE**: In your final `## References` section, you MUST ONLY include the specific files and events from which data was explicitly extracted. Do NOT include broad discovery results or unused tool outputs.
-    -   **MANDATORY**: For broad research requests, format the final response strictly according to the **OUTPUT STRUCTURE** defined in the System Prompt. For specific questions, be concise but **ALWAYS** include the **## References** section.
+Cross-correlate all findings into a unified narrative before writing the response. Every response MUST follow this exact section order. Omit a section only if genuinely no data exists for it — in that case write `No information found` under that heading, do not skip the heading entirely.
+
+---
+
+**Summary** *(always present)*
+1–2 paragraphs. Brief context of what was found, the topic, and its relevance. No bullet points here.
+
+---
+
+**## Key Points**
+Bullet list of the most important facts, decisions, dates, and findings extracted from the sources.
+
+---
+
+**## Stakeholders**
+Bullet list of people involved: name, role or relationship to the topic, and contact email when available.
+
+---
+
+**## Upcoming Meetings**
+List ONLY meetings occurring after the current date that are directly related to the project, company, or topic the user asked about. For each entry include: date, time, title, and participants.
+If none found: `No upcoming meetings found for this topic.`
+
+---
+
+**## Previous Meetings**
+List meetings from the 1-month past window (Phase 2 Calendar broad search) that are related to the project, company, or topic the user asked about. For each entry include: date, title, and key participants.
+If none found: `No recent meetings found for this topic.`
+
+---
+
+**## References**
+Markdown table. Include ONLY the files, documents, and events from which data was explicitly extracted to produce this response. NEVER include broad discovery results or unused tool outputs.
+
+| Source | Filename | Owner | Created at / Last Update |
+|:---:|:---:|:---:|:---:|
+| EKB / Drive / Cloud Storage / BigQuery (`dataset.table`) | Human-readable file or event name | Author email or display name | `YYYY-MM-DD` |
+
+-   **Source**: one of `EKB`, `Drive`, `Cloud Storage`, or `BigQuery (dataset.table)` — use the most specific label, e.g. `BigQuery (knowledge_base.documents_metadata)`.
+-   **Filename**: human-readable name or event title. NEVER show raw IDs, hashes, or GCS URIs.
+-   **Owner**: uploader email, document owner, or event organizer. Use `Unknown` if unavailable.
+-   **Created at / Last Update**: `YYYY-MM-DD`. Use `Unknown` if unavailable.
+
+---
+
+**## Extend Search?** *(include ONLY when Level 5 is reached — all standard sources exhausted with no relevant results)*
+Begin with one sentence stating which sources were searched and what terms were used. Then include this question verbatim:
+
+> "I have searched the Enterprise Knowledge Base, Google Calendar, and Google Drive using the available context and found no matching data. Would you like me to extend the search to your personal GCS buckets or BigQuery tables? If yes, please share the bucket name, path prefix, or table/dataset identifier and I will search there directly."
+
+This section MUST appear after `## References` at Level 5. Omitting it when Level 5 is reached means the task is incomplete.

--- a/agent/skills/meeting-summary/SKILL.md
+++ b/agent/skills/meeting-summary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meeting-summary
-description: create a meeting summary document from a transcript, notes, or meeting file using a fixed template and save the finished .docx to the user's drive. use when the user asks to summarize a meeting file, summarize a transcript from drive, create a meeting summary document, use a meeting-summary template, or save the summary into drive. this skill should be preferred over generic summarization whenever the request includes a meeting file, a named meeting, a template, or document creation.
+description: create a meeting summary document from a transcript, notes, or meeting file using a fixed template and save the finished .doc to the user's drive. use when the user asks to summarize a meeting file, summarize a transcript from drive, create a meeting summary document, use a meeting-summary template, or save the summary into drive. this skill should be preferred over generic summarization whenever the request includes a meeting file, a named meeting, a template, or document creation.
 ---
 
 ## Mandatory execution mode
@@ -20,7 +20,7 @@ Instead, execute the full workflow:
 1. identify the meeting
 2. retrieve source evidence
 3. extract the 8 required fields
-4. generate the .docx from the template
+4. generate the .doc from the template
 5. save the file to Drive
 6. return only the completion report
 
@@ -122,6 +122,8 @@ Populate the placeholders and preserve this section order:
 7. Date of the future session
 8. Documents that could be useful
 
+Save the document using `create_file` with `mime_type = "application/msword"` to produce a `.doc` file.
+
 ## Document generation rule
 
 After extracting the fields, populate the template document with those exact sections and save the document file.
@@ -214,7 +216,7 @@ Folder behavior:
 - If creation is blocked, save in the nearest user-approved equivalent and explicitly say so.
 
 Filename format:
-`YYYY-MM-DD - meeting-name - Summary.docx`
+`YYYY-MM-DD - meeting-name - Summary.doc`
 
 Filename normalization rules:
 - Use the meeting date from the source meeting. If unavailable, use `undated`.

--- a/agent/tests/test_app_builder.py
+++ b/agent/tests/test_app_builder.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 from agent.core_agent.builder import AppBuilder
-from agent.core_agent.config import GCPConfig, AgentConfig
+from agent.core_agent.config import GCPConfig, CoordinatorConfig
 from agent.core_agent.plugins.ingestion.plugin import (
     GeminiEnterpriseFileIngestionPlugin,
 )
@@ -31,7 +31,7 @@ def mock_configs():
             PROD_EXECUTION=True, ARTIFACT_BUCKET="test-bucket", REGION="us-central1"
         ),
         "gcp_local": GCPConfig(PROD_EXECUTION=False),
-        "agent": AgentConfig(AGENT_NAME="test_agent"),
+        "agent": CoordinatorConfig(AGENT_NAME="test_agent"),
     }
 
 

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -163,10 +163,8 @@ def test_build_disable_artifact_rendering_clears_callback(
 ):
     """Test that build(enable_artifact_rendering=False) sets after_agent_callback to None.
 
-    Sub-agents must not have render_pending_artifacts as after_agent_callback because
-    AgentTool discards file_data parts and only returns merged text, so any rendering
-    done inside the sub-agent is lost and the state keys are cleared before the
-    coordinator's callback can render them.
+    Used for specialists that never produce file_data output (e.g., ingestion-only agents)
+    to skip the render_pending_artifacts callback overhead.
     """
     builder = AgentBuilder(
         agent_config=mock_configs["agent"],
@@ -206,7 +204,7 @@ def test_with_output_key_sets_key_on_agent(
 def test_build_passes_description_to_agent(
     mock_agent_class, mock_vertex_client, mock_configs
 ):
-    """Test that build() passes the config's AGENT_DESCRIPTION to Agent for AgentTool declarations."""
+    """Test that build() passes the config's AGENT_DESCRIPTION to Agent for sub_agents= routing."""
     from agent.core_agent.config import ResearchAgentConfig
 
     builder = AgentBuilder(

--- a/agent/tests/test_builder.py
+++ b/agent/tests/test_builder.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 from agent.core_agent.builder import AgentBuilder
 from agent.core_agent.config import (
-    AgentConfig,
+    CoordinatorConfig,
     GCPConfig,
     GoogleAuthConfig,
     BigQueryMCPConfig,
@@ -12,7 +12,7 @@ from agent.core_agent.config import (
 @pytest.fixture
 def mock_configs():
     return {
-        "agent": AgentConfig(),
+        "agent": CoordinatorConfig(),
         "gcp": GCPConfig(PROJECT_ID="test-project", REGION="us-central1"),
         "auth": GoogleAuthConfig(),
     }
@@ -94,3 +94,128 @@ def test_agent_builder_empty_registered_tools(mock_vertex_client, mock_configs):
     with patch("agent.core_agent.builder.agent_builder.Agent") as mock_agent:
         builder.build()
         assert mock_agent.call_args[1]["tools"] == []
+
+
+@patch("agent.core_agent.builder.agent_builder.vertexai.Client")
+def test_agent_builder_with_subagents(mock_vertex_client, mock_configs):
+    """Test that with_subagents appends each agent to _sub_agents for LLM-transfer delegation."""
+    builder = AgentBuilder(
+        agent_config=mock_configs["agent"],
+        gcp_config=mock_configs["gcp"],
+        auth_config=mock_configs["auth"],
+    )
+
+    mock_sub_agent = MagicMock()
+    mock_sub_agent.name = "test_specialist"
+
+    result = builder.with_subagents([mock_sub_agent])
+
+    assert mock_sub_agent in builder._sub_agents
+    assert mock_sub_agent not in builder._registered_tools
+    assert result is builder
+
+
+@patch("agent.core_agent.builder.agent_builder.vertexai.Client")
+@patch("agent.core_agent.builder.agent_builder.Agent")
+def test_agent_builder_subagents_appear_in_sub_agents_param(
+    mock_agent_class, mock_vertex_client, mock_configs
+):
+    """Test that sub-agents mounted via with_subagents are passed via sub_agents=, not tools=."""
+    builder = AgentBuilder(
+        agent_config=mock_configs["agent"],
+        gcp_config=mock_configs["gcp"],
+        auth_config=mock_configs["auth"],
+    )
+
+    mock_sub_agent = MagicMock()
+    mock_sub_agent.name = "specialist"
+
+    builder.with_subagents([mock_sub_agent]).build()
+
+    _, kwargs = mock_agent_class.call_args
+    assert mock_sub_agent in kwargs["sub_agents"]
+    assert mock_sub_agent not in kwargs["tools"]
+
+
+@patch("agent.core_agent.builder.agent_builder.vertexai.Client")
+@patch("agent.core_agent.builder.agent_builder.Agent")
+def test_build_default_enables_artifact_rendering(
+    mock_agent_class, mock_vertex_client, mock_configs
+):
+    """Test that build() with default args sets after_agent_callback to render_pending_artifacts."""
+    from agent.core_agent.callbacks.artifact_rendering import render_pending_artifacts
+
+    builder = AgentBuilder(
+        agent_config=mock_configs["agent"],
+        gcp_config=mock_configs["gcp"],
+        auth_config=mock_configs["auth"],
+    )
+    builder.build()
+
+    _, kwargs = mock_agent_class.call_args
+    assert kwargs["after_agent_callback"] is render_pending_artifacts
+
+
+@patch("agent.core_agent.builder.agent_builder.vertexai.Client")
+@patch("agent.core_agent.builder.agent_builder.Agent")
+def test_build_disable_artifact_rendering_clears_callback(
+    mock_agent_class, mock_vertex_client, mock_configs
+):
+    """Test that build(enable_artifact_rendering=False) sets after_agent_callback to None.
+
+    Sub-agents must not have render_pending_artifacts as after_agent_callback because
+    AgentTool discards file_data parts and only returns merged text, so any rendering
+    done inside the sub-agent is lost and the state keys are cleared before the
+    coordinator's callback can render them.
+    """
+    builder = AgentBuilder(
+        agent_config=mock_configs["agent"],
+        gcp_config=mock_configs["gcp"],
+        auth_config=mock_configs["auth"],
+    )
+    builder.build(enable_artifact_rendering=False)
+
+    _, kwargs = mock_agent_class.call_args
+    assert kwargs["after_agent_callback"] is None
+
+
+@patch("agent.core_agent.builder.agent_builder.vertexai.Client")
+@patch("agent.core_agent.builder.agent_builder.Agent")
+def test_with_output_key_sets_key_on_agent(
+    mock_agent_class, mock_vertex_client, mock_configs
+):
+    """Test that with_output_key persists the key to the built Agent for session state memory."""
+    builder = AgentBuilder(
+        agent_config=mock_configs["agent"],
+        gcp_config=mock_configs["gcp"],
+        auth_config=mock_configs["auth"],
+    )
+    result = builder.with_output_key("research_context")
+
+    assert result is builder
+    assert builder._output_key == "research_context"
+
+    builder.build()
+
+    _, kwargs = mock_agent_class.call_args
+    assert kwargs["output_key"] == "research_context"
+
+
+@patch("agent.core_agent.builder.agent_builder.vertexai.Client")
+@patch("agent.core_agent.builder.agent_builder.Agent")
+def test_build_passes_description_to_agent(
+    mock_agent_class, mock_vertex_client, mock_configs
+):
+    """Test that build() passes the config's AGENT_DESCRIPTION to Agent for AgentTool declarations."""
+    from agent.core_agent.config import ResearchAgentConfig
+
+    builder = AgentBuilder(
+        agent_config=ResearchAgentConfig(),
+        gcp_config=mock_configs["gcp"],
+        auth_config=mock_configs["auth"],
+    )
+    builder.build()
+
+    _, kwargs = mock_agent_class.call_args
+    assert kwargs["description"] != ""
+    assert "knowledge" in kwargs["description"].lower()

--- a/agent/tests/test_config.py
+++ b/agent/tests/test_config.py
@@ -5,7 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from agent.core_agent.config import (
-    AgentConfig,
+    CoordinatorConfig,
     BigQueryMCPConfig,
     CalendarMCPConfig,
     DriveMCPConfig,
@@ -71,21 +71,21 @@ def test_gcs_mcp_config_default_scopes_include_identity():
 
 
 def test_agent_config_validation():
-    """Test that AgentConfig enforces data types and constraints."""
+    """Test that CoordinatorConfig enforces data types and constraints inherited from BaseAgentConfig."""
     with patch.dict(os.environ, clear=True):
-        config = AgentConfig()
+        config = CoordinatorConfig()
         assert config.TEMPERATURE == 0.3
 
     mock_env_invalid = {"TEMPERATURE": "1.5"}
     with patch.dict(os.environ, mock_env_invalid, clear=True):
         with pytest.raises(ValidationError) as exc_info:
-            AgentConfig()
+            CoordinatorConfig()
         assert "Input should be less than or equal to 1" in str(exc_info.value)
 
     mock_env_invalid_low = {"TEMPERATURE": "-0.5"}
     with patch.dict(os.environ, mock_env_invalid_low, clear=True):
         with pytest.raises(ValidationError) as exc_info:
-            AgentConfig()
+            CoordinatorConfig()
         assert "Input should be greater than or equal to 0" in str(exc_info.value)
 
 

--- a/docs/AI-Agent-Development/12-Multi-Agent-Architecture.md
+++ b/docs/AI-Agent-Development/12-Multi-Agent-Architecture.md
@@ -1,0 +1,270 @@
+# 12 - Multi-Agent Architecture
+
+This document describes the rationale, design, and implementation of the Research-Agent's multi-agent topology, which replaced the original monolithic single-agent design.
+
+---
+
+## 1. Rationale: Why Multi-Agent?
+
+The original Research-Agent was a single `Agent` instance that owned all MCP servers, skills, and tools in one flat toolset. While functional, this design introduced scaling problems as the system grew:
+
+| Limitation | Impact |
+| :--- | :--- |
+| **No task specialization** | The LLM had to reason over all available tools (Calendar, Drive, BigQuery, GCS, EKB pipeline) for every request, increasing the likelihood of misdirected tool calls. |
+| **No cross-turn research memory** | Research results were not persisted to session state, so follow-up questions required full re-discovery from scratch. |
+| **No separation of concerns** | EKB ingestion tools and knowledge research tools shared a single system prompt and toolset, introducing role ambiguity for the model. |
+| **Single point of instruction** | Adding new skills or MCP servers made the system prompt longer and the model's routing decisions noisier. |
+
+The multi-agent refactor introduces a **Coordinator → Specialist** topology that addresses all four limitations by giving each agent a distinct identity, toolset, and system prompt.
+
+---
+
+## 2. Architecture Overview
+
+The system is composed of three agents, each built with an `AgentBuilder` and wired together via the `sub_agents=` parameter on the Coordinator.
+
+```mermaid
+graph TD
+    User["User (Gemini Enterprise)"]
+    Coord["Coordinator\ncore_agent"]
+
+    subgraph research_specialist
+        direction TB
+        R_Skills["Skills\nmeeting-summary · knowledge-discovery"]
+        R_MCP["MCP Servers\nBigQuery · Drive · Calendar · GCS"]
+        R_Tools["Native Tools\nGetArtifactUri · ImportGcsToArtifact\nGetCurrentTime · load_artifacts"]
+    end
+
+    subgraph ingestion_specialist
+        direction TB
+        I_Skills["Skills\nkb-file-ingestion"]
+        I_Tools["Native Tools\nTriggerEKBPipeline · CheckIngestionStatus\nload_artifacts"]
+    end
+
+    subgraph coordinator_tools
+        direction TB
+        C_Tools["Native Tools\nGetArtifactUri · load_artifacts"]
+    end
+
+    User --> Coord
+    Coord -->|"sub_agents= delegation"| research_specialist
+    Coord -->|"sub_agents= delegation"| ingestion_specialist
+    Coord --> coordinator_tools
+```
+
+### Agent Roles
+
+| Agent | Config Class | Responsibility |
+| :--- | :--- | :--- |
+| **Coordinator** (`root_agent`) | `CoordinatorConfig` | Primary user interface. Routes requests to specialists, retrieves artifact URIs, and synthesizes final responses. Never performs deep research or ingestion directly. |
+| **Research Specialist** (`research_agent`) | `ResearchAgentConfig` | Multi-source discovery across EKB, BigQuery, Drive, Calendar, and GCS. Retains research results across turns via `output_key`. |
+| **Ingestion Specialist** (`ingestion_agent`) | `IngestionAgentConfig` | Triggers and monitors the EKB ingestion pipeline. |
+
+---
+
+## 3. Delegation Pattern: LLM-Transfer via `sub_agents=`
+
+Specialists are registered on the Coordinator using the `sub_agents=` parameter of the ADK `Agent` class. When the Coordinator's LLM recognizes that a request matches a specialist's declared `description`, it issues a **transfer** to that specialist. No new session is created — the specialist runs within the same invocation context.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant Coord as Coordinator
+    participant Research as Research Specialist
+    participant Calendar as Calendar MCP
+    participant GE as Gemini Enterprise
+
+    User->>Coord: "Summarize my meetings with Team X"
+
+    Note over Coord: LLM reads specialist descriptions<br/>and decides to transfer
+
+    Coord->>Research: LLM-Transfer (same session context)
+
+    Research->>Calendar: list_calendar_events(...)
+    Calendar-->>Research: Events
+
+    Research-->>Coord: Summary + state_delta
+    Coord-->>GE: Synthesized response
+    GE-->>User: Rendered response
+```
+
+> [!IMPORTANT]
+> The `sub_agents=` pattern preserves the **same invocation context**: coordinator and specialists share session state, credentials, and event channels. This is the key distinction from the `AgentTool` pattern. See [AgentTool-vs-SubAgents.md](AgentTool-vs-SubAgents.md) for a full technical comparison.
+
+---
+
+## 4. Why `sub_agents=` Instead of `AgentTool`
+
+The initial implementation of this branch used `AgentTool` (explicit tool invocation) to expose specialists as callable tools, which would have enabled Gemini's native parallel function calling. However, `AgentTool` creates an **isolated session** for each specialist call, which caused three critical failures:
+
+| Failure | Root Cause |
+| :--- | :--- |
+| **OAuth challenges silently dropped** | `AgentTool` runs the specialist in a new `InMemorySessionService`. OAuth `requested_auth_configs` events emitted inside the isolated session cannot escape to the user's session. |
+| **`file_data` content stripped** | `AgentTool.run_async` extracts only `.text` parts from the specialist's final response. `file_data` parts (rendered artifacts) are discarded. |
+| **`after_agent_callback` ineffective** | `render_pending_artifacts` fires inside the isolated session, but its `file_data` output is dropped before the coordinator sees it. State keys are cleared, so the coordinator's own callback also finds nothing. |
+
+Reverting to `sub_agents=` resolves all three because specialists share the parent session's event channel and storage context. See [AgentTool-vs-SubAgents.md](AgentTool-vs-SubAgents.md) for the internal mechanics.
+
+---
+
+## 5. Cross-Turn Research Memory
+
+The Research Specialist is configured with an `output_key`:
+
+```python
+research_agent = (
+    AgentBuilder(...)
+    .with_output_key("research_context")
+    .build()
+)
+```
+
+After every research turn, the ADK framework writes the specialist's final text response to `session.state["research_context"]`. On subsequent turns, the Coordinator passes this prior context to the specialist when delegating, enabling follow-up questions without full re-discovery.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Coord as Coordinator
+    participant Research as Research Specialist
+    participant State as session.state
+
+    User->>Coord: "Tell me about Project X"
+    Coord->>Research: Delegate
+
+    Research->>Research: Multi-source discovery
+    Research-->>State: state["research_context"] = "Project X details..."
+    Research-->>Coord: "Project X is..."
+    Coord-->>User: Response
+
+    User->>Coord: "Who are the leads on that project?"
+    Coord->>Research: Delegate (state["research_context"] available)
+    Note over Research: Prior context in state — no full re-discovery
+    Research-->>Coord: "The leads are..."
+    Coord-->>User: Response
+```
+
+---
+
+## 6. OAuth Propagation in the Multi-Agent Context
+
+With `sub_agents=` delegation, specialists run inside the same invocation context as the Coordinator. OAuth token access works correctly in both environments:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Coord as Coordinator
+    participant Research as Research Specialist
+    participant MCP as Drive MCP
+    participant GE as Gemini Enterprise
+
+    rect rgb(235, 245, 235)
+        Note over User, GE: Production — token injected by Gemini Enterprise
+        GE->>Coord: Call with session.state[auth_id] = token
+        Coord->>Research: LLM-Transfer (state shared)
+        Research->>MCP: list_files() — header_provider reads state[auth_id]
+        MCP-->>Research: Files
+        Research-->>User: Results
+    end
+
+    rect rgb(245, 235, 235)
+        Note over User, GE: Local dev — token not yet in state
+        Coord->>Research: LLM-Transfer
+        Research->>MCP: list_files() — no token
+        MCP-->>Research: 401 Unauthorized
+        Research-->>Coord: auth_required event propagates
+        Coord-->>User: OAuth consent URL shown to user
+    end
+```
+
+- **Production**: Gemini Enterprise injects the OAuth token into `session.state[auth_id]`. Because state is shared, `get_ge_oauth_token(ctx, auth_id)` in the MCP `header_provider` reads the token directly from the specialist's context.
+- **Local development**: If no token is in state, the MCP tool emits a `requested_auth_configs` event. Because `sub_agents=` shares the event channel, the OAuth challenge **reaches the user's browser** — unlike `AgentTool`, which silently drops it.
+
+---
+
+## 7. Artifact Rendering in the Multi-Agent Context
+
+With `sub_agents=` delegation, each specialist's `after_agent_callback` fires within the same session and its output is visible to the user:
+
+| Agent | `enable_artifact_rendering` | Rationale |
+| :--- | :---: | :--- |
+| Research Specialist | `True` (default) | Imports GCS files and uses `render_pending_artifacts`; rendered `file_data` parts must reach the user. |
+| Ingestion Specialist | `False` | Produces only text status responses; no file rendering needed. |
+| Coordinator | `True` (default) | Root agent — renders any artifacts queued by tools it called directly. |
+
+The `render_pending_artifacts` callback clears `PENDING_RENDER_KEY` and `PENDING_URI_KEY` from session state after rendering. If both a specialist and the coordinator attempt to render, only the first caller finds data — no duplication occurs.
+
+For a full description of the stash-and-render pattern, see [09-Architecture-and-Deduplication.md](09-Architecture-and-Deduplication.md).
+
+---
+
+## 8. The AgentBuilder Pattern
+
+All three agents are assembled using the fluent `AgentBuilder` in `agent/core_agent/agent.py`:
+
+```python
+# Research Specialist
+research_agent = (
+    AgentBuilder(agent_config=RESEARCH_AGENT_CONFIG, gcp_config=GCP_CONFIG, auth_config=GOOGLE_AUTH_CONFIG)
+    .with_skills(["meeting-summary", "knowledge-discovery"])
+    .with_mcp_servers([BIGQUERY_MCP_CONFIG, DRIVE_MCP_CONFIG, CALENDAR_MCP_CONFIG, GCS_MCP_CONFIG])
+    .with_native_tools([GetArtifactUriTool(), ImportGcsToArtifactTool(), GetCurrentTimeTool(), load_artifacts])
+    .with_output_key("research_context")
+    .build()
+)
+
+# Ingestion Specialist
+ingestion_agent = (
+    AgentBuilder(agent_config=INGESTION_AGENT_CONFIG, gcp_config=GCP_CONFIG, auth_config=GOOGLE_AUTH_CONFIG)
+    .with_skills(["kb-file-ingestion"])
+    .with_native_tools([TriggerEKBPipelineTool(), CheckIngestionStatusTool(), load_artifacts])
+    .build(enable_artifact_rendering=False)
+)
+
+# Coordinator (Root Agent)
+root_agent = (
+    AgentBuilder(agent_config=COORDINATOR_CONFIG, gcp_config=GCP_CONFIG, auth_config=GOOGLE_AUTH_CONFIG)
+    .with_subagents([research_agent, ingestion_agent])
+    .with_before_agent_callback(sync_ingestion_status)
+    .with_native_tools([GetArtifactUriTool(), load_artifacts])
+    .build()
+)
+```
+
+### Builder Method Reference
+
+| Method | Description |
+| :--- | :--- |
+| `with_skills(names)` | Loads ADK `SkillToolset` entries from `agent/skills/`. |
+| `with_mcp_servers(configs)` | Creates an `McpToolset` for each MCP server config via `MCPToolsetBuilder`. |
+| `with_native_tools(tools)` | Registers `BaseTool` instances or plain callables (auto-wrapped in `FunctionTool`). |
+| `with_subagents(agents)` | Registers specialist agents via `sub_agents=` LLM-transfer delegation. |
+| `with_output_key(key)` | Persists the agent's final text to `session.state[key]` for cross-turn memory. |
+| `with_before_agent_callback(fn)` | Sets the `before_agent_callback` (e.g., `sync_ingestion_status`). |
+| `build(enable_artifact_rendering)` | Assembles the `Agent`. Pass `False` for specialists that never emit `file_data`. |
+
+---
+
+## 9. Configuration Design
+
+Each agent has its own Pydantic `BaseSettings` subclass carrying its name, system prompt, and capability description:
+
+```
+BaseAgentConfig
+├── CoordinatorConfig       # AGENT_NAME = "core_agent"
+├── ResearchAgentConfig     # AGENT_NAME = "research_specialist"
+│                           # AGENT_DESCRIPTION = "Retrieves and synthesizes..."
+└── IngestionAgentConfig    # AGENT_NAME = "ingestion_specialist"
+                            # AGENT_DESCRIPTION = "Triggers and monitors EKB..."
+```
+
+The `AGENT_DESCRIPTION` field is passed to the `Agent` constructor as `description=`. The ADK framework exposes this to the parent coordinator's LLM, which uses it to decide which specialist to transfer to.
+
+Global singletons are instantiated in `agent/core_agent/config/agent_settings.py` and imported by `agent/core_agent/agent.py`:
+
+```python
+GCP_CONFIG            = GCPConfig()
+COORDINATOR_CONFIG    = CoordinatorConfig()
+RESEARCH_AGENT_CONFIG = ResearchAgentConfig()
+INGESTION_AGENT_CONFIG = IngestionAgentConfig()
+GOOGLE_AUTH_CONFIG    = GoogleAuthConfig()
+```

--- a/docs/AI-Agent-Development/AgentTool-vs-SubAgents.md
+++ b/docs/AI-Agent-Development/AgentTool-vs-SubAgents.md
@@ -1,0 +1,233 @@
+# AgentTool vs. `sub_agents=` — Two Delegation Patterns in ADK
+
+When building multi-agent systems with Google ADK, there are two distinct mechanisms for connecting a Coordinator agent to specialist agents. Each has a different internal execution model with significant implications for session sharing, OAuth propagation, and artifact rendering.
+
+---
+
+## Overview
+
+| Dimension | `AgentTool` | `sub_agents=` |
+| :--- | :--- | :--- |
+| **API** | `AgentTool(agent=spec)` → `tools=[...]` | `Agent(..., sub_agents=[spec])` |
+| **Invocation trigger** | Coordinator's LLM calls it like a function tool | Coordinator's LLM transfers control via agent description |
+| **Session** | **Isolated** — new `InMemorySessionService` per call | **Shared** — same session and invocation context |
+| **Parallelism** | ✅ Multiple specialists can run in one LLM turn | ❌ Sequential — one specialist per turn |
+| **OAuth propagation** | ❌ Auth events dropped at isolation boundary | ✅ Auth events reach the user |
+| **`file_data` in response** | ❌ Stripped — only `.text` parts forwarded | ✅ Full content forwarded |
+| **`after_agent_callback`** | ❌ Fires inside isolated session, effects discarded | ✅ Fires in user's session, effects visible |
+
+---
+
+## Pattern 1: `AgentTool` — Explicit Tool Invocation
+
+### Concept
+
+`AgentTool` wraps a specialist `Agent` as a regular callable tool. The Coordinator's function-calling LLM can invoke it explicitly — like calling any other tool — and can call multiple specialists in a single turn if needed.
+
+### Internal Mechanics
+
+When the Coordinator invokes an `AgentTool`, the ADK runtime creates a fully isolated execution environment for the specialist:
+
+```python
+# Simplified from google.adk.tools.agent_tool.AgentTool.run_async
+runner = Runner(
+    session_service=InMemorySessionService(),           # ← NEW isolated session
+    credential_service=tool_context.credential_service, # shared credentials
+    artifact_service=tool_context.artifact_service,     # shared artifact store
+    ...
+)
+
+# Only non-_adk-prefixed state keys are copied from the parent
+state_dict = {
+    k: v for k, v in tool_context.state.to_dict().items()
+    if not k.startswith("_adk")
+}
+session = await runner.session_service.create_session(state=state_dict)
+```
+
+After the specialist completes, `AgentTool` filters its output before returning to the Coordinator:
+
+```python
+async for event in specialist_runner:
+    if event.actions.state_delta:
+        tool_context.state.update(event.actions.state_delta)  # forwarded
+    if event.content:
+        last_content = event.content
+
+# Only text is extracted — file_data parts are discarded:
+return "\n".join(
+    part.text for part in last_content.parts
+    if part.text and not part.thought
+)
+```
+
+### Event Flow
+
+```mermaid
+sequenceDiagram
+    participant Coord as Coordinator
+    participant AT as AgentTool Runtime
+    participant Spec as Specialist Agent
+    participant MCP as MCP Server
+
+    Coord->>AT: Invoke as tool call
+    AT->>AT: Create isolated InMemorySessionService
+    AT->>AT: Copy state (excluding _adk_ keys)
+    AT->>Spec: Run specialist in isolated session
+
+    Spec->>MCP: Tool call requires OAuth
+    MCP-->>Spec: requested_auth_configs event
+    Note over AT: OAuth challenge DROPPED at boundary
+
+    Spec->>Spec: render_pending_artifacts callback fires
+    Spec-->>Spec: Emits file_data Content
+    Note over AT: file_data Content DROPPED
+
+    AT-->>Coord: state_delta forwarded
+    AT-->>Coord: Merged text (parts.text only) forwarded
+```
+
+### What Is and Is Not Forwarded
+
+| Forwarded to Coordinator | Dropped at Isolation Boundary |
+| :--- | :--- |
+| `state_delta` (non-`_adk` keys) | `requested_auth_configs` (OAuth challenges) |
+| Final response text (`.text` parts only) | `file_data` parts in final response |
+| — | Effects of `after_agent_callback` on content |
+
+### When to Use `AgentTool`
+
+- **Parallel specialist execution is required** and specialists do not use OAuth or return `file_data`.
+- **Hard session isolation is desired** — each specialist invocation is fully sandboxed.
+- **Deterministic, explicit invocation** is preferred over LLM-driven routing.
+
+**Example use case**: A coordinator that orchestrates two pure-text summarisation agents — one for documents and one for emails — and calls both in parallel on each user request.
+
+---
+
+## Pattern 2: `sub_agents=` — LLM-Transfer Delegation
+
+### Concept
+
+Specialist agents are listed in the `sub_agents=` parameter of the `Agent` constructor. The Coordinator's LLM reads each specialist's `description` field and, when it determines a request matches, **transfers control** to that specialist. No new session is created.
+
+### Internal Mechanics
+
+The ADK `Runner` manages the transfer. The specialist runs in the **same `InvocationContext`** as the Coordinator, with full access to the parent session's state, credentials, event channel, and artifact service.
+
+State flows naturally in both directions:
+
+- **Coordinator → Specialist**: The specialist reads `session.state` directly (no copying needed).
+- **Specialist → Coordinator**: Any `state_delta` the specialist produces is written to the shared session immediately.
+
+### Event Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Runner as ADK Runner
+    participant Coord as Coordinator
+    participant Spec as Specialist Agent
+    participant MCP as MCP Server
+
+    User->>Runner: User message
+    Runner->>Coord: Run turn
+
+    Note over Coord: LLM reads specialist descriptions<br/>Decides to transfer
+
+    Coord->>Runner: transfer_to_agent(specialist_name)
+    Runner->>Spec: Run turn in SAME InvocationContext
+
+    Spec->>MCP: Tool call requires OAuth
+    MCP-->>Spec: requested_auth_configs event
+    Spec-->>Runner: Event propagates through shared channel
+    Runner-->>User: OAuth consent URL shown
+
+    Spec->>Spec: render_pending_artifacts callback fires
+    Spec-->>Runner: file_data Content in response
+    Runner-->>User: File visible in Gemini Enterprise UI
+
+    Spec-->>Runner: state_delta written to shared session
+    Runner-->>Coord: Specialist result
+    Coord-->>User: Synthesized response
+```
+
+### What Propagates
+
+Because the same session is active throughout:
+
+| Capability | Behavior |
+| :--- | :--- |
+| `requested_auth_configs` (OAuth challenges) | ✅ Propagate to user |
+| `file_data` parts in final response | ✅ Reach the user |
+| `after_agent_callback` effects | ✅ Fire in user's session, visible |
+| `session.state` reads | ✅ Full shared access (no copy, no exclusions) |
+| `state_delta` writes | ✅ Immediately visible in shared session |
+
+### When to Use `sub_agents=`
+
+- **Any specialist uses OAuth** (e.g., MCP servers for Drive, Calendar, BigQuery).
+- **Any specialist returns `file_data` content** (e.g., artifact rendering, PDF imports).
+- **`after_agent_callback` effects must be visible** to the user (e.g., `render_pending_artifacts`).
+- **Routing logic is well-described** by the specialist's `description` field.
+
+**Example use case**: A coordinator that delegates deep research to a specialist that authenticates against Drive and Calendar MCP servers via OAuth and returns rendered GCS files to the user.
+
+---
+
+## Decision Guide
+
+```mermaid
+flowchart TD
+    A["Need to connect a coordinator to specialists?"] --> B{"Does any specialist\nuse OAuth MCP tools?"}
+    B -- Yes --> SUB["Use sub_agents="]
+    B -- No --> C{"Does any specialist\nreturn file_data content?"}
+    C -- Yes --> SUB
+    C -- No --> D{"Is parallel specialist\nexecution required?"}
+    D -- Yes --> AT["Use AgentTool"]
+    D -- No --> SUB
+```
+
+| Decision Factor | `AgentTool` | `sub_agents=` |
+| :--- | :---: | :---: |
+| Specialist uses OAuth MCP tools | ❌ | ✅ |
+| Specialist returns `file_data` / rendered artifacts | ❌ | ✅ |
+| `after_agent_callback` must reach user | ❌ | ✅ |
+| Parallel specialist execution needed | ✅ | ❌ |
+| Hard session isolation / sandboxing required | ✅ | ❌ |
+| Explicit, deterministic call control | ✅ | ❌ |
+
+**Rule of thumb**: Choose `sub_agents=` unless you explicitly need parallel specialist execution **and** your specialists do not use OAuth or produce file content.
+
+---
+
+## This Project's Choice and Why
+
+The Research-Agent uses `sub_agents=` delegation. Three concrete requirements drove this decision:
+
+### 1. MCP OAuth Propagation
+
+The Research Specialist connects to Drive, Calendar, BigQuery, and GCS MCP servers — all protected by OAuth 2.0. In local development, the OAuth consent challenge must reach the user's browser to complete the flow. `AgentTool` silently drops `requested_auth_configs` events at the session boundary; `sub_agents=` shares the event channel.
+
+### 2. Artifact Rendering
+
+The Research Specialist uses `render_pending_artifacts` as its `after_agent_callback`. This callback produces `file_data` parts that must appear in the final user-visible response. With `AgentTool`, these parts are stripped by the text-only extraction step. With `sub_agents=`, they flow through the shared session to the user.
+
+### 3. Cross-Turn Research Memory
+
+The specialist uses `output_key="research_context"` to persist findings to `session.state`. While `AgentTool` does copy `state_delta` back to the parent, the direct shared-state model of `sub_agents=` provides cleaner semantics: the coordinator and specialist always agree on what is in state without copy-and-exclusion logic.
+
+> [!NOTE]
+> The initial implementation on the `multiagent_refactor` branch used `AgentTool` with the goal of enabling parallel specialist calls. It was reverted to `sub_agents=` after confirming that OAuth challenges were silently dropped and rendered artifacts were stripped. Parallel execution was deprioritized in favour of correctness.
+
+### Why Not a Hybrid?
+
+A hybrid approach — some specialists via `AgentTool`, some via `sub_agents=` — is technically valid but adds architectural complexity and requires per-specialist reasoning about session boundaries. Since all specialists in this system require OAuth and produce file content, `sub_agents=` is the uniform choice.
+
+---
+
+## Related Documents
+
+- **[12-Multi-Agent-Architecture.md](12-Multi-Agent-Architecture.md)**: Full architecture of the three-agent topology and the AgentBuilder pattern.
+- **[06-OAuth-Inside-Gemini-Enterprise.md](06-OAuth-Inside-Gemini-Enterprise.md)**: OAuth flow details and the `get_ge_oauth_token` helper.
+- **[09-Architecture-and-Deduplication.md](09-Architecture-and-Deduplication.md)**: Stash-and-render pattern and `render_pending_artifacts` callback.

--- a/docs/AI-Agent-Development/README.md
+++ b/docs/AI-Agent-Development/README.md
@@ -15,4 +15,11 @@ We recommend reviewing these documents logically as they walk through building, 
 7. **[07-Artifacts-Management.md](07-Artifacts-Management.md)**: End-to-end management of session artifacts and multi-modal documents.
 8. **[08-GCS-Artifact-Transfer.md](08-GCS-Artifact-Transfer.md)**: Secure transfer of artifacts to the Enterprise Knowledge Base landing zone.
 9. **[09-Architecture-and-Deduplication.md](09-Architecture-and-Deduplication.md)**: Advanced App construction and recursive artifact prevention.
+10. **[10-User-Uploads-ACL.md](10-User-Uploads-ACL.md)**: IAM identity management for user-uploaded files in Gemini Enterprise.
+11. **[11-KB-Ingestion-Pipeline.md](11-KB-Ingestion-Pipeline.md)**: KB ingestion module: tools for triggering and monitoring EKB pipeline runs.
+12. **[12-Multi-Agent-Architecture.md](12-Multi-Agent-Architecture.md)**: Coordinator → Specialist multi-agent topology: rationale, delegation patterns, OAuth, and artifact rendering.
+
+## Reference
+
+- **[AgentTool-vs-SubAgents.md](AgentTool-vs-SubAgents.md)**: Deep-dive comparison of the two ADK multi-agent delegation patterns — `AgentTool` (explicit tool invocation) vs. `sub_agents=` (LLM-transfer) — covering internal mechanics, event propagation, and a decision guide.
 


### PR DESCRIPTION
## Summary

Migrates the Research-Agent from a monolithic single-agent design to a **Coordinator → Specialist** multi-agent topology using Google ADK's `sub_agents=` LLM-transfer delegation pattern.

- **Coordinator** (`core_agent`) — sole user-facing agent; routes requests, retrieves artifact URIs, synthesizes responses.
- **Research Specialist** (`research_specialist`) — owns all MCP servers (BigQuery, Drive, Calendar, GCS), knowledge-discovery and meeting-summary skills, and artifact tools. Persists findings to `session.state["research_context"]` via `output_key` for cross-turn memory.
- **Ingestion Specialist** (`ingestion_specialist`) — owns the EKB pipeline tools and kb-file-ingestion skill.

## Why `sub_agents=` instead of `AgentTool`

An earlier iteration used `AgentTool` (explicit tool invocation) to enable parallel specialist calls. It was reverted because `AgentTool` creates an isolated `InMemorySessionService` per call, which:

1. **Drops OAuth challenges** — `requested_auth_configs` events emitted inside the isolated session never reach the user.
2. **Strips `file_data`** — `AgentTool` extracts only `.text` from the specialist's final response.
3. **Discards `after_agent_callback` effects** — `render_pending_artifacts` fires inside the isolated session but its file content is thrown away.

`sub_agents=` delegation shares the same invocation context, so all three propagate correctly.

## Changes

| Area | What changed |
|---|---|
| `config/agent_settings.py` | Split monolithic `AgentConfig` into `CoordinatorConfig`, `ResearchAgentConfig`, `IngestionAgentConfig`, each with `AGENT_NAME`, `AGENT_INSTRUCTION`, and `AGENT_DESCRIPTION`. |
| `builder/agent_builder.py` | Added `with_subagents()` (using `sub_agents=`), `with_output_key()`, `with_before_agent_callback()`, and `enable_artifact_rendering` flag on `build()`. |
| `core_agent/agent.py` | Wires the three-agent topology. Research specialist built with `output_key="research_context"`; ingestion specialist with `enable_artifact_rendering=False`. |
| Tests | Updated fixtures (`AgentConfig` → `CoordinatorConfig`); added 6 new tests covering new builder methods. 90/90 passing. |
| Docs | Added `12-Multi-Agent-Architecture.md` and `AgentTool-vs-SubAgents.md` with Mermaid diagrams; updated README index. |

## Test plan

- [x] `make run-agent-precommit` — ruff lint + format pass
- [x] `make test-agent` — 90/90 tests pass
