### PR TITLE
MCP Servers / Cloud Storage / Fix - Remove explicit scopes from SA credentials

### DIFF
--- a/mcp_servers/gcs/README.md
+++ b/mcp_servers/gcs/README.md
@@ -186,3 +186,4 @@ If you prefer direct command usage without `make`:
 ```bash
 uv run --group mcp_gcs python mcp_servers/gcs/scripts/mcp_smoke_test.py --endpoint http://localhost:8080/mcp --bucket mikes-bucket --prefix docs/ --bucket-prefix my- 
 ```
+ 

--- a/mcp_servers/gcs/app/gcs_client.py
+++ b/mcp_servers/gcs/app/gcs_client.py
@@ -332,13 +332,19 @@ def build_gcs_credentials(
     )
 
 
-def build_sa_credentials(scopes: Optional[Sequence[str]] = None) -> Credentials:
+def build_sa_credentials() -> Credentials:
     """
     Builds credentials using Application Default Credentials (the Cloud Run SA).
+
+    Scopes are intentionally not specified: on Cloud Run the metadata server issues
+    a cloud-platform token by default, and passing explicit scopes would restrict it.
+    IAM roles on the SA govern what operations are permitted, not OAuth scopes.
+
+    Returns:
+        Credentials -> The ADC credentials for the ambient service account.
     """
-    scopes = list(scopes or GCS_API_CONFIG.read_write_scopes)
     try:
-        creds, _ = google.auth.default(scopes=scopes)
+        creds, _ = google.auth.default()
         logger.info("Using Application Default Credentials (SA).")
         return creds
     except Exception as e:

--- a/mcp_servers/gcs/app/mcp_server.py
+++ b/mcp_servers/gcs/app/mcp_server.py
@@ -450,7 +450,7 @@ async def list_buckets(request: ListBucketsRequest) -> ListBucketsResponse:
 def _make_gcs_manager(use_sa: bool = False) -> GCSManager:
     """Creates a GCS manager using either the delegated user token or the environment SA."""
     if use_sa:
-        creds = build_sa_credentials(scopes=GCS_API_CONFIG.read_write_scopes)
+        creds = build_sa_credentials()
     else:
         access_token = _get_current_token()
         creds = build_gcs_credentials(

--- a/mcp_servers/gcs/tests/test_mcp_server.py
+++ b/mcp_servers/gcs/tests/test_mcp_server.py
@@ -267,10 +267,36 @@ def test_make_gcs_manager_uses_sa_credentials_when_requested():
         manager = _make_gcs_manager(use_sa=True)
 
     assert manager == "manager"
-    mock_build_sa.assert_called_once_with(scopes=GCS_API_CONFIG.read_write_scopes)
+    # SA credentials must be fetched without explicit scopes so the Cloud Run
+    # metadata server returns its full cloud-platform token unrestricted.
+    mock_build_sa.assert_called_once_with()
     mock_manager.assert_called_once_with(
         "sa-creds", default_project=GCS_SERVER_CONFIG.default_project_id
     )
+
+
+def test_sa_credentials_do_not_pass_explicit_scopes():
+    """build_sa_credentials must be called without scopes.
+
+    Passing explicit OAuth scopes to google.auth.default() on Cloud Run restricts
+    the metadata-server token. IAM roles on the SA already govern permissions;
+    scopes should be left to the execution environment.
+    """
+    with (
+        patch(
+            "mcp_servers.gcs.app.mcp_server.build_sa_credentials",
+            return_value="sa-creds",
+        ) as mock_build_sa,
+        patch(
+            "mcp_servers.gcs.app.mcp_server.GCSManager",
+            return_value="manager",
+        ),
+    ):
+        _make_gcs_manager(use_sa=True)
+
+    mock_build_sa.assert_called_once_with()
+    assert mock_build_sa.call_args.args == ()
+    assert mock_build_sa.call_args.kwargs == {}
 
 
 def test_mcp_update_object_metadata_success_sa_flow(mock_gcs_manager):


### PR DESCRIPTION
## Summary

- `build_sa_credentials()` was calling `google.auth.default(scopes=["devstorage.read_write"])`, which **restricts** the Cloud Run metadata-server token to that narrow scope instead of using the default `cloud-platform` token
- `blob.patch()` (`storage.objects.patch`) requires a broader scope than `read_write`, so every call to `update_object_metadata` on the KB landing zone bucket returned `403 Provided scope(s) are not authorized`
- Fix: removed the explicit `scopes` argument entirely — IAM roles on the SA govern what operations are permitted; OAuth scopes should be left to the execution environment

## Changes

| File | Change |
|---|---|
| `gcs_client.py` | `build_sa_credentials()` — removed `scopes` param and the `google.auth.default(scopes=...)` call |
| `mcp_server.py` | `_make_gcs_manager(use_sa=True)` calls `build_sa_credentials()` with no arguments |
| `test_mcp_server.py` | Updated SA assertion to `assert_called_once_with()` (no args); added `test_sa_credentials_do_not_pass_explicit_scopes` regression test |

## Test plan

- [ ] `make run-gcs-tests` — all 29 tests pass
- [ ] `make run-gcs-precommit` — ruff + ruff-format clean
- [ ] Deploy GCS MCP Server to Cloud Run and retry the EKB upload flow: `update_object_metadata` on `ag-core-dev-fdx7-kb-landing-zone` should return `200` instead of `403`
