### PR TITLE
AI Agent / Fix - Resolve 'Internal Error:' on Multi-File trigger_ekb_pipeline tool

### DIFF
--- a/agent/core_agent/tools/README.md
+++ b/agent/core_agent/tools/README.md
@@ -20,3 +20,4 @@ agent_builder.with_native_tools([
     ImportGcsToArtifactTool()
 ])
 ```
+

--- a/agent/core_agent/tools/kb_tools.py
+++ b/agent/core_agent/tools/kb_tools.py
@@ -17,15 +17,12 @@ from .kb_schemas import (
 # Key for storing pending jobs in session state
 PENDING_INGESTIONS_KEY = "pending_ingestions"
 
-# Global client to share connection pool across multiple requests
-limits = httpx.Limits(max_keepalive_connections=50, max_connections=100)
-http_client = httpx.AsyncClient(limits=limits)
+# Connection pool limits for outbound HTTP requests
+_CLIENT_LIMITS = httpx.Limits(max_keepalive_connections=50, max_connections=100)
 
 
 class TriggerEKBPipelineTool(BaseTool):
     """Triggers the Enterprise Knowledge Base (EKB) ingestion pipeline."""
-
-    client = http_client
 
     def __init__(self) -> None:
         """Registers the tool for background processing of documents."""
@@ -73,43 +70,80 @@ class TriggerEKBPipelineTool(BaseTool):
         Returns:
             dict -> Serialised TriggerEKBPipelineResponse.
         """
-        logger.info(f"Triggering EKB pipeline for {args.get('gcs_uri')}")
+        raw_uri = args.get("gcs_uri")
+        logger.info(f"[trigger_ekb_pipeline] Invoked with gcs_uri='{raw_uri}'")
+
         try:
+            # Step 1: Validate and parse input via Pydantic schema
+            logger.debug(
+                "[trigger_ekb_pipeline] Step 1/5: Validating request schema..."
+            )
             request = TriggerEKBPipelineRequest(**args)
             gcs_uri = request.gcs_uri
+            filename = request.filename
+            logger.debug(
+                f"[trigger_ekb_pipeline] Step 1/5: Schema valid. URI='{gcs_uri}', filename='{filename}'"
+            )
 
+            # Step 2: Resolve target URL
             url = f"{AGENT_CONFIG.EKB_PIPELINE_URL.strip('/')}/ingest"
-            id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
+            logger.debug(
+                f"[trigger_ekb_pipeline] Step 2/5: Target URL resolved to '{url}'"
+            )
 
+            # Step 3: Obtain OIDC identity token
+            logger.debug(
+                "[trigger_ekb_pipeline] Step 3/5: Fetching OIDC identity token..."
+            )
+            id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
             if not id_token:
+                logger.error(
+                    "[trigger_ekb_pipeline] Step 3/5: FAILED — could not obtain ID token. "
+                    f"Target audience: '{AGENT_CONFIG.EKB_PIPELINE_URL}'"
+                )
                 return TriggerEKBPipelineResponse(
                     execution_status="error",
                     execution_message="Authentication failed: Could not obtain ID token.",
                     job_id="N/A",
                 ).model_dump()
+            logger.debug(
+                "[trigger_ekb_pipeline] Step 3/5: ID token obtained successfully."
+            )
 
+            # Step 4: POST to Cloud Run /ingest
             headers = {
                 "Authorization": f"Bearer {id_token}",
                 "Content-Type": "application/json",
             }
             payload = {"gcs_uri": gcs_uri}
+            logger.debug(
+                f"[trigger_ekb_pipeline] Step 4/5: POSTing payload to '{url}': {payload}"
+            )
 
-            response = await self.client.post(
-                url, json=payload, headers=headers, timeout=30.0
+            async with httpx.AsyncClient(limits=_CLIENT_LIMITS) as client:
+                response = await client.post(
+                    url, json=payload, headers=headers, timeout=30.0
+                )
+
+            logger.debug(
+                f"[trigger_ekb_pipeline] Step 4/5: Received HTTP {response.status_code} from EKB service."
             )
             response.raise_for_status()
             data = response.json()
+            logger.debug(f"[trigger_ekb_pipeline] Step 4/5: Response body: {data}")
 
+            # Step 5: Persist job in session state
             job_id = data.get("job_id")
-            filename = request.filename
-
-            # Store in session state for proactive status checks
+            logger.debug(
+                f"[trigger_ekb_pipeline] Step 5/5: Persisting job_id='{job_id}' for file='{filename}' in session state..."
+            )
             pending = list(tool_context.state.get(PENDING_INGESTIONS_KEY, []))
             pending.append({"job_id": job_id, "filename": filename})
             tool_context.state[PENDING_INGESTIONS_KEY] = pending
 
             logger.info(
-                f"Stored pending ingestion in state: {filename} ({job_id}). Total pending: {len(pending)}"
+                f"[trigger_ekb_pipeline] Step 5/5: Done. job_id='{job_id}', filename='{filename}'. "
+                f"Total pending jobs in state: {len(pending)}"
             )
 
             return TriggerEKBPipelineResponse(
@@ -122,8 +156,11 @@ class TriggerEKBPipelineTool(BaseTool):
                 job_id=job_id,
                 response=data,
             ).model_dump()
+
         except Exception as e:
-            logger.error(f"Failed to trigger EKB pipeline: {e}")
+            logger.opt(exception=True).error(
+                f"[trigger_ekb_pipeline] FAILED for uri='{raw_uri}': {type(e).__name__}: {e}"
+            )
             return TriggerEKBPipelineResponse(
                 execution_status="error",
                 execution_message=f"Internal Error: {str(e)}",
@@ -133,8 +170,6 @@ class TriggerEKBPipelineTool(BaseTool):
 
 class CheckIngestionStatusTool(BaseTool):
     """Checks the status of a specific EKB ingestion job."""
-
-    client = http_client
 
     def __init__(self) -> None:
         super().__init__(
@@ -176,13 +211,32 @@ class CheckIngestionStatusTool(BaseTool):
         Returns:
             dict -> Serialised CheckIngestionStatusResponse.
         """
-        logger.info(f"Checking ingestion status for job_id: {args.get('job_id')}")
-        try:
-            request = CheckIngestionStatusRequest(**args)
-            url = f"{AGENT_CONFIG.EKB_PIPELINE_URL.strip('/')}/status/{request.job_id}"
-            id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
+        raw_job_id = args.get("job_id")
+        logger.info(f"[check_ingestion_status] Invoked with job_id='{raw_job_id}'")
 
+        try:
+            # Step 1: Validate input
+            logger.debug(
+                "[check_ingestion_status] Step 1/3: Validating request schema..."
+            )
+            request = CheckIngestionStatusRequest(**args)
+            logger.debug(
+                f"[check_ingestion_status] Step 1/3: Schema valid. job_id='{request.job_id}'"
+            )
+
+            # Step 2: Resolve URL and obtain auth token
+            url = f"{AGENT_CONFIG.EKB_PIPELINE_URL.strip('/')}/status/{request.job_id}"
+            logger.debug(f"[check_ingestion_status] Step 2/3: Status URL='{url}'")
+
+            logger.debug(
+                "[check_ingestion_status] Step 2/3: Fetching OIDC identity token..."
+            )
+            id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
             if not id_token:
+                logger.error(
+                    "[check_ingestion_status] Step 2/3: FAILED — could not obtain ID token. "
+                    f"Target audience: '{AGENT_CONFIG.EKB_PIPELINE_URL}'"
+                )
                 return CheckIngestionStatusResponse(
                     job_id=request.job_id,
                     status="error",
@@ -190,19 +244,30 @@ class CheckIngestionStatusTool(BaseTool):
                     execution_status="error",
                     execution_message="Authentication failed",
                 ).model_dump()
+            logger.debug("[check_ingestion_status] Step 2/3: ID token obtained.")
 
+            # Step 3: GET status from EKB service
             headers = {"Authorization": f"Bearer {id_token}"}
-            response = await self.client.get(url, headers=headers, timeout=10.0)
             logger.debug(
-                f"Response status from EKB for {request.job_id}: {response.status_code}"
+                f"[check_ingestion_status] Step 3/3: GETting status for job_id='{request.job_id}'..."
+            )
+            async with httpx.AsyncClient(limits=_CLIENT_LIMITS) as client:
+                response = await client.get(url, headers=headers, timeout=10.0)
+
+            logger.debug(
+                f"[check_ingestion_status] Step 3/3: Received HTTP {response.status_code} for job_id='{request.job_id}'."
             )
             response.raise_for_status()
             data = response.json()
-            logger.info(f"Retrieved status for {request.job_id}: {data.get('status')}")
+            job_status = data.get("status")
+            logger.info(
+                f"[check_ingestion_status] Step 3/3: job_id='{request.job_id}' → status='{job_status}'"
+            )
             return CheckIngestionStatusResponse(**data).model_dump()
+
         except Exception as e:
-            logger.error(
-                f"Error checking ingestion status for job {args.get('job_id')}: {e}"
+            logger.opt(exception=True).error(
+                f"[check_ingestion_status] FAILED for job_id='{raw_job_id}': {type(e).__name__}: {e}"
             )
             return CheckIngestionStatusResponse(
                 job_id=args.get("job_id", "N/A"),

--- a/agent/tests/test_kb_tools.py
+++ b/agent/tests/test_kb_tools.py
@@ -1,35 +1,147 @@
+import asyncio
 import pytest
 import httpx
-from unittest.mock import patch, MagicMock
-from agent.core_agent.tools.kb_tools import TriggerEKBPipelineTool
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent.core_agent.tools.kb_tools import (
+    TriggerEKBPipelineTool,
+    CheckIngestionStatusTool,
+    PENDING_INGESTIONS_KEY,
+)
 
 pytestmark = pytest.mark.asyncio
 
 
+def _make_mock_response(
+    status_code: int, json_body: dict, raise_error: Exception | None = None
+):
+    """Builds a reusable mock HTTP response."""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_body
+    if raise_error:
+        mock.raise_for_status.side_effect = raise_error
+    else:
+        mock.raise_for_status = MagicMock()
+    return mock
+
+
+def _build_async_client_mock(response: MagicMock, method: str = "post") -> MagicMock:
+    """
+    Builds an AsyncClient context-manager mock that returns the given response
+    when the specified HTTP method is awaited.
+    """
+    client_mock = MagicMock()
+    setattr(client_mock, method, AsyncMock(return_value=response))
+    # async with httpx.AsyncClient(...) as client → __aenter__ returns the mock client
+    async_ctx_mock = MagicMock()
+    async_ctx_mock.__aenter__ = AsyncMock(return_value=client_mock)
+    async_ctx_mock.__aexit__ = AsyncMock(return_value=False)
+    return async_ctx_mock
+
+
+# ---------------------------------------------------------------------------
+# TriggerEKBPipelineTool
+# ---------------------------------------------------------------------------
+
+
 class TestTriggerEKBPipelineTool:
     @patch("agent.core_agent.tools.kb_tools.get_id_token")
-    @patch("httpx.AsyncClient.post")
-    async def test_trigger_pipeline_success(self, mock_post, mock_get_token):
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_trigger_pipeline_success(
+        self, mock_async_client_cls, mock_get_token
+    ):
         """Happy path: pipeline is triggered successfully with OIDC auth."""
         mock_get_token.return_value = "mock-id-token"
 
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"job_id": "123"}
-        mock_response.raise_for_status = MagicMock()
-        mock_post.return_value = mock_response
+        mock_response = _make_mock_response(200, {"job_id": "job-abc-123"})
+        mock_async_client_cls.return_value = _build_async_client_mock(
+            mock_response, "post"
+        )
 
         tool = TriggerEKBPipelineTool()
         ctx = MagicMock()
+        ctx.state = {}
 
         args = {"gcs_uri": "gs://kb-landing-zone/project/doc.pdf"}
         result = await tool.run_async(args=args, tool_context=ctx)
 
         assert result["execution_status"] == "success"
-        assert result["response"]["job_id"] == "123"
-        mock_post.assert_called_once()
-        headers = mock_post.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer mock-id-token"
+        assert result["job_id"] == "job-abc-123"
+        assert result["response"]["job_id"] == "job-abc-123"
+
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_trigger_pipeline_stores_pending_job_in_state(
+        self, mock_async_client_cls, mock_get_token
+    ):
+        """Happy path: job_id and filename are persisted in tool_context state."""
+        mock_get_token.return_value = "mock-id-token"
+
+        mock_response = _make_mock_response(200, {"job_id": "job-xyz-789"})
+        mock_async_client_cls.return_value = _build_async_client_mock(
+            mock_response, "post"
+        )
+
+        tool = TriggerEKBPipelineTool()
+        ctx = MagicMock()
+        ctx.state = {}
+
+        await tool.run_async(
+            args={"gcs_uri": "gs://kb-landing-zone/project/report.pdf"},
+            tool_context=ctx,
+        )
+
+        pending = ctx.state.get(PENDING_INGESTIONS_KEY, [])
+        assert len(pending) == 1
+        assert pending[0]["job_id"] == "job-xyz-789"
+        assert pending[0]["filename"] == "report.pdf"
+
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_trigger_pipeline_accumulates_multiple_files_in_state(
+        self, mock_async_client_cls, mock_get_token
+    ):
+        """
+        Regression test for the multi-file bug: calling trigger_ekb_pipeline
+        for two different files should accumulate both entries in session state
+        without raising an error.
+        """
+        mock_get_token.return_value = "mock-id-token"
+
+        # Each call to httpx.AsyncClient() returns a fresh mock response
+        responses = [
+            _make_mock_response(200, {"job_id": "job-file-1"}),
+            _make_mock_response(200, {"job_id": "job-file-2"}),
+        ]
+        mock_async_client_cls.side_effect = [
+            _build_async_client_mock(responses[0], "post"),
+            _build_async_client_mock(responses[1], "post"),
+        ]
+
+        tool = TriggerEKBPipelineTool()
+        ctx = MagicMock()
+        ctx.state = {}
+
+        result1 = await tool.run_async(
+            args={"gcs_uri": "gs://kb-landing-zone/project/file1.pdf"},
+            tool_context=ctx,
+        )
+        result2 = await tool.run_async(
+            args={"gcs_uri": "gs://kb-landing-zone/project/file2.pdf"},
+            tool_context=ctx,
+        )
+
+        assert result1["execution_status"] == "success"
+        assert result1["job_id"] == "job-file-1"
+
+        assert result2["execution_status"] == "success"
+        assert result2["job_id"] == "job-file-2"
+
+        pending = ctx.state.get(PENDING_INGESTIONS_KEY, [])
+        assert len(pending) == 2
+        assert pending[0]["filename"] == "file1.pdf"
+        assert pending[1]["filename"] == "file2.pdf"
 
     @patch("agent.core_agent.tools.kb_tools.get_id_token")
     async def test_trigger_pipeline_auth_failure(self, mock_get_token):
@@ -44,9 +156,10 @@ class TestTriggerEKBPipelineTool:
 
         assert result["execution_status"] == "error"
         assert "Authentication failed" in result["execution_message"]
+        assert result["job_id"] == "N/A"
 
     async def test_trigger_pipeline_missing_args(self):
-        """Failure mode: missing mandatory 'gcs_uri' returns Pydantic validation error."""
+        """Edge case: missing mandatory 'gcs_uri' returns Pydantic validation error."""
         tool = TriggerEKBPipelineTool()
         ctx = MagicMock()
 
@@ -55,16 +168,34 @@ class TestTriggerEKBPipelineTool:
         assert result["execution_status"] == "error"
         assert "validation error" in result["execution_message"].lower()
 
+    async def test_trigger_pipeline_invalid_gcs_uri(self):
+        """Edge case: a URI that fails the gs:// pattern validator is caught and returned."""
+        tool = TriggerEKBPipelineTool()
+        ctx = MagicMock()
+
+        result = await tool.run_async(
+            args={"gcs_uri": "https://not-a-gcs-uri/file.pdf"},
+            tool_context=ctx,
+        )
+
+        assert result["execution_status"] == "error"
+
     @patch("agent.core_agent.tools.kb_tools.get_id_token")
-    @patch("httpx.AsyncClient.post")
-    async def test_trigger_pipeline_service_error(self, mock_post, mock_get_token):
-        """Failure mode: handles HTTP errors from the Cloud Run service."""
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_trigger_pipeline_service_error(
+        self, mock_async_client_cls, mock_get_token
+    ):
+        """Failure mode: handles HTTP 500 errors from the Cloud Run service."""
         mock_get_token.return_value = "mock-id-token"
 
-        mock_post.side_effect = httpx.HTTPStatusError(
+        http_error = httpx.HTTPStatusError(
             message="Internal Server Error",
             request=MagicMock(),
             response=MagicMock(status_code=500, text="Internal Server Error"),
+        )
+        mock_response = _make_mock_response(500, {}, raise_error=http_error)
+        mock_async_client_cls.return_value = _build_async_client_mock(
+            mock_response, "post"
         )
 
         tool = TriggerEKBPipelineTool()
@@ -75,3 +206,125 @@ class TestTriggerEKBPipelineTool:
 
         assert result["execution_status"] == "error"
         assert "Internal Error" in result["execution_message"]
+
+
+# ---------------------------------------------------------------------------
+# CheckIngestionStatusTool
+# ---------------------------------------------------------------------------
+
+
+class TestCheckIngestionStatusTool:
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_check_status_success(self, mock_async_client_cls, mock_get_token):
+        """Happy path: returns full status response for a known job."""
+        mock_get_token.return_value = "mock-id-token"
+
+        status_payload = {
+            "job_id": "job-abc-123",
+            "status": "success",
+            "message": "Pipeline completed.",
+            "gcs_uri": "gs://kb-domain/it/doc.pdf",
+            "chunks_generated": 42,
+            "final_domain": "it",
+            "security_tier": "tier-1",
+        }
+        mock_response = _make_mock_response(200, status_payload)
+        mock_async_client_cls.return_value = _build_async_client_mock(
+            mock_response, "get"
+        )
+
+        tool = CheckIngestionStatusTool()
+        ctx = MagicMock()
+
+        result = await tool.run_async(args={"job_id": "job-abc-123"}, tool_context=ctx)
+
+        assert result["execution_status"] == "success"
+        assert result["job_id"] == "job-abc-123"
+        assert result["status"] == "success"
+        assert result["chunks_generated"] == 42
+
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    async def test_check_status_auth_failure(self, mock_get_token):
+        """Failure mode: graceful degradation when auth token is unavailable."""
+        mock_get_token.return_value = None
+
+        tool = CheckIngestionStatusTool()
+        ctx = MagicMock()
+
+        result = await tool.run_async(args={"job_id": "job-abc-123"}, tool_context=ctx)
+
+        assert result["execution_status"] == "error"
+        assert (
+            "Auth failed" in result["execution_message"]
+            or "Authentication" in result["execution_message"]
+        )
+
+    async def test_check_status_missing_job_id(self):
+        """Edge case: missing 'job_id' argument raises a validation error."""
+        tool = CheckIngestionStatusTool()
+        ctx = MagicMock()
+
+        result = await tool.run_async(args={}, tool_context=ctx)
+
+        assert result["execution_status"] == "error"
+
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_check_status_service_unavailable(
+        self, mock_async_client_cls, mock_get_token
+    ):
+        """Failure mode: network error during status check is caught and returned."""
+        mock_get_token.return_value = "mock-id-token"
+
+        client_mock = MagicMock()
+        client_mock.get = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        async_ctx = MagicMock()
+        async_ctx.__aenter__ = AsyncMock(return_value=client_mock)
+        async_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_async_client_cls.return_value = async_ctx
+
+        tool = CheckIngestionStatusTool()
+        ctx = MagicMock()
+
+        result = await tool.run_async(args={"job_id": "job-abc-123"}, tool_context=ctx)
+
+        assert result["execution_status"] == "error"
+
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_check_status_concurrent_calls(
+        self, mock_async_client_cls, mock_get_token
+    ):
+        """
+        Regression test: concurrent status checks for two different jobs must
+        each return the correct, independent results without cross-contamination.
+        """
+        mock_get_token.return_value = "mock-id-token"
+
+        job1_payload = {"job_id": "job-1", "status": "success", "message": "Done."}
+        job2_payload = {
+            "job_id": "job-2",
+            "status": "processing",
+            "message": "Still running.",
+        }
+
+        mock_async_client_cls.side_effect = [
+            _build_async_client_mock(_make_mock_response(200, job1_payload), "get"),
+            _build_async_client_mock(_make_mock_response(200, job2_payload), "get"),
+        ]
+
+        tool = CheckIngestionStatusTool()
+        ctx = MagicMock()
+
+        result1, result2 = await asyncio.gather(
+            tool.run_async(args={"job_id": "job-1"}, tool_context=ctx),
+            tool.run_async(args={"job_id": "job-2"}, tool_context=ctx),
+        )
+
+        assert result1["job_id"] == "job-1"
+        assert result1["status"] == "success"
+        assert result2["job_id"] == "job-2"
+        assert result2["status"] == "processing"


### PR DESCRIPTION
## Summary

Fixes a bug where calling `trigger_ekb_pipeline` for **more than one file** in a session consistently returned `execution_status: "error"` with an empty `execution_message: "Internal Error: "`.

---

## Root Cause

`TriggerEKBPipelineTool` and `CheckIngestionStatusTool` both referenced a **single module-level `httpx.AsyncClient`** as a shared class attribute:

```python
# Before — UNSAFE
http_client = httpx.AsyncClient(limits=limits)

class TriggerEKBPipelineTool(BaseTool):
    client = http_client  # shared across all invocations
```

`httpx.AsyncClient` is bound to the event loop that created it. When the ADK agent triggered the tool for a **second file**, the second `run_async` invocation hit the same client instance from a different async context (or while the previous connection was still draining). This produced a `RuntimeError` whose `str()` representation is an **empty string** — exactly matching the observed `"Internal Error: "` response with no detail after the colon.

---

## Fix

Replaced the shared global client with an **`async with httpx.AsyncClient()` context manager per request** — the idiomatic httpx pattern for request-scoped usage:

```python
# After — SAFE
_CLIENT_LIMITS = httpx.Limits(max_keepalive_connections=50, max_connections=100)

async with httpx.AsyncClient(limits=_CLIENT_LIMITS) as client:
    response = await client.post(url, json=payload, headers=headers, timeout=30.0)
```

Each invocation now creates a fresh, properly-scoped client and closes it cleanly after, regardless of concurrent calls.

---

## Additional Improvements

### Enhanced Observability
Added granular **step-by-step logs** to both tools so future failures are immediately traceable in Cloud Run logs:
- **`TriggerEKBPipelineTool`**: Steps 1–5 covering schema validation → URL resolution → OIDC token → HTTP POST → session state persistence.
- **`CheckIngestionStatusTool`**: Steps 1–3 covering schema validation → URL + auth → HTTP GET.
- Full exception tracebacks via `logger.opt(exception=True).error()` (correct loguru idiom).

### Expanded Test Coverage (4 → 12 tests)
| New Test | Scenario |
|---|---|
| `test_trigger_pipeline_stores_pending_job_in_state` | Validates session state persistence |
| `test_trigger_pipeline_accumulates_multiple_files_in_state` | **Regression test** for the multi-file bug |
| `test_trigger_pipeline_invalid_gcs_uri` | Edge case: non-`gs://` URI rejected by Pydantic |
| `test_check_status_success` | Happy path for CheckIngestionStatusTool |
| `test_check_status_auth_failure` | Auth failure handling |
| `test_check_status_missing_job_id` | Missing argument validation |
| `test_check_status_service_unavailable` | Network error resilience |
| `test_check_status_concurrent_calls` | Concurrent checks return independent results |

All 12 tests pass ✅

---

## Files Changed
- `agent/core_agent/tools/kb_tools.py` — core fix + logging
- `agent/tests/test_kb_tools.py` — expanded test suite