### PR TITLE
AI Agent / EKB Pipeline / Fix - Resolve ReadTimeout on trigger_ekb_pipeline and Parallel Ingestion

### DIFF
--- a/agent/core_agent/tools/kb_tools.py
+++ b/agent/core_agent/tools/kb_tools.py
@@ -14,11 +14,27 @@ from .kb_schemas import (
     CheckIngestionStatusResponse,
 )
 
-# Key for storing pending jobs in session state
 PENDING_INGESTIONS_KEY = "pending_ingestions"
 
-# Connection pool limits for outbound HTTP requests
 _CLIENT_LIMITS = httpx.Limits(max_keepalive_connections=50, max_connections=100)
+
+
+def _get_bearer_headers(audience: str, tool_name: str) -> Optional[dict[str, str]]:
+    """
+    Fetches an OIDC token for the given audience and returns bearer auth headers.
+
+    Args:
+        audience: str -> The Cloud Run service URL used as the OIDC audience.
+        tool_name: str -> Tool identifier used in log messages.
+
+    Returns:
+        Optional[dict[str, str]] -> Auth headers dict, or None if token is unavailable.
+    """
+    id_token = get_id_token(audience)
+    if not id_token:
+        logger.error(f"[{tool_name}] Could not obtain ID token for '{audience}'")
+        return None
+    return {"Authorization": f"Bearer {id_token}", "Content-Type": "application/json"}
 
 
 class TriggerEKBPipelineTool(BaseTool):
@@ -58,6 +74,52 @@ class TriggerEKBPipelineTool(BaseTool):
             ),
         )
 
+    async def _post_to_ingest(
+        self, url: str, headers: dict[str, str], gcs_uri: str
+    ) -> dict:
+        """
+        POSTs the ingestion payload to the EKB pipeline /ingest endpoint.
+
+        Args:
+            url: str -> Full URL of the /ingest endpoint.
+            headers: dict[str, str] -> Authorization and content-type headers.
+            gcs_uri: str -> Canonical GCS URI of the document to ingest.
+
+        Returns:
+            dict -> Parsed JSON response body from the pipeline service.
+        """
+        logger.debug(f"[trigger_ekb_pipeline] POSTing to '{url}': gcs_uri='{gcs_uri}'")
+        async with httpx.AsyncClient(limits=_CLIENT_LIMITS) as client:
+            response = await client.post(
+                url, json={"gcs_uri": gcs_uri}, headers=headers, timeout=120.0
+            )
+        logger.debug(
+            f"[trigger_ekb_pipeline] HTTP {response.status_code} from EKB service."
+        )
+        response.raise_for_status()
+        data = response.json()
+        logger.debug(f"[trigger_ekb_pipeline] Response body: {data}")
+        return data
+
+    def _store_pending_job(
+        self, tool_context: ToolContext, job_id: str, filename: str
+    ) -> int:
+        """
+        Appends a pending job entry to the session state and returns the new total.
+
+        Args:
+            tool_context: ToolContext -> ADK context for session state access.
+            job_id: str -> The job ID returned by the pipeline service.
+            filename: str -> The filename of the document being ingested.
+
+        Returns:
+            int -> Total number of pending jobs after appending.
+        """
+        pending = list(tool_context.state.get(PENDING_INGESTIONS_KEY, []))
+        pending.append({"job_id": job_id, "filename": filename})
+        tool_context.state[PENDING_INGESTIONS_KEY] = pending
+        return len(pending)
+
     @override
     async def run_async(self, *, args: dict, tool_context: ToolContext) -> dict:
         """
@@ -72,84 +134,34 @@ class TriggerEKBPipelineTool(BaseTool):
         """
         raw_uri = args.get("gcs_uri")
         logger.info(f"[trigger_ekb_pipeline] Invoked with gcs_uri='{raw_uri}'")
-
         try:
-            # Step 1: Validate and parse input via Pydantic schema
-            logger.debug(
-                "[trigger_ekb_pipeline] Step 1/5: Validating request schema..."
-            )
             request = TriggerEKBPipelineRequest(**args)
-            gcs_uri = request.gcs_uri
-            filename = request.filename
             logger.debug(
-                f"[trigger_ekb_pipeline] Step 1/5: Schema valid. URI='{gcs_uri}', filename='{filename}'"
+                f"[trigger_ekb_pipeline] Request valid — uri='{request.gcs_uri}', filename='{request.filename}'"
             )
-
-            # Step 2: Resolve target URL
             url = f"{AGENT_CONFIG.EKB_PIPELINE_URL.strip('/')}/ingest"
-            logger.debug(
-                f"[trigger_ekb_pipeline] Step 2/5: Target URL resolved to '{url}'"
+            headers = _get_bearer_headers(
+                AGENT_CONFIG.EKB_PIPELINE_URL, "trigger_ekb_pipeline"
             )
-
-            # Step 3: Obtain OIDC identity token
-            logger.debug(
-                "[trigger_ekb_pipeline] Step 3/5: Fetching OIDC identity token..."
-            )
-            id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
-            if not id_token:
-                logger.error(
-                    "[trigger_ekb_pipeline] Step 3/5: FAILED — could not obtain ID token. "
-                    f"Target audience: '{AGENT_CONFIG.EKB_PIPELINE_URL}'"
-                )
+            if not headers:
                 return TriggerEKBPipelineResponse(
                     execution_status="error",
                     execution_message="Authentication failed: Could not obtain ID token.",
                     job_id="N/A",
                 ).model_dump()
-            logger.debug(
-                "[trigger_ekb_pipeline] Step 3/5: ID token obtained successfully."
-            )
 
-            # Step 4: POST to Cloud Run /ingest
-            headers = {
-                "Authorization": f"Bearer {id_token}",
-                "Content-Type": "application/json",
-            }
-            payload = {"gcs_uri": gcs_uri}
-            logger.debug(
-                f"[trigger_ekb_pipeline] Step 4/5: POSTing payload to '{url}': {payload}"
-            )
-
-            async with httpx.AsyncClient(limits=_CLIENT_LIMITS) as client:
-                response = await client.post(
-                    url, json=payload, headers=headers, timeout=30.0
-                )
-
-            logger.debug(
-                f"[trigger_ekb_pipeline] Step 4/5: Received HTTP {response.status_code} from EKB service."
-            )
-            response.raise_for_status()
-            data = response.json()
-            logger.debug(f"[trigger_ekb_pipeline] Step 4/5: Response body: {data}")
-
-            # Step 5: Persist job in session state
+            data = await self._post_to_ingest(url, headers, request.gcs_uri)
             job_id = data.get("job_id")
-            logger.debug(
-                f"[trigger_ekb_pipeline] Step 5/5: Persisting job_id='{job_id}' for file='{filename}' in session state..."
+            total_pending = self._store_pending_job(
+                tool_context, job_id, request.filename
             )
-            pending = list(tool_context.state.get(PENDING_INGESTIONS_KEY, []))
-            pending.append({"job_id": job_id, "filename": filename})
-            tool_context.state[PENDING_INGESTIONS_KEY] = pending
-
             logger.info(
-                f"[trigger_ekb_pipeline] Step 5/5: Done. job_id='{job_id}', filename='{filename}'. "
-                f"Total pending jobs in state: {len(pending)}"
+                f"[trigger_ekb_pipeline] Done — job_id='{job_id}', filename='{request.filename}', pending={total_pending}"
             )
-
             return TriggerEKBPipelineResponse(
                 execution_status="success",
                 execution_message=(
-                    f"I've started the ingestion process for '{filename}'. "
+                    f"I've started the ingestion process for '{request.filename}'. "
                     "It usually takes about 10 minutes to classify and index the document. "
                     "I'll let you know once it's finished!"
                 ),
@@ -163,7 +175,7 @@ class TriggerEKBPipelineTool(BaseTool):
             )
             return TriggerEKBPipelineResponse(
                 execution_status="error",
-                execution_message=f"Internal Error: {str(e)}",
+                execution_message=f"Internal Error: {type(e).__name__}: {e}",
                 job_id="N/A",
             ).model_dump()
 
@@ -172,6 +184,7 @@ class CheckIngestionStatusTool(BaseTool):
     """Checks the status of a specific EKB ingestion job."""
 
     def __init__(self) -> None:
+        """Initialises the tool with its name and description."""
         super().__init__(
             name="check_ingestion_status",
             description="Checks the current status of an EKB ingestion job using its Job ID.",
@@ -199,6 +212,22 @@ class CheckIngestionStatusTool(BaseTool):
             ),
         )
 
+    async def _fetch_job_status(self, url: str, headers: dict[str, str]) -> dict:
+        """
+        GETs the current status of an ingestion job from the EKB service.
+
+        Args:
+            url: str -> Full URL of the /status/{job_id} endpoint.
+            headers: dict[str, str] -> Authorization headers.
+
+        Returns:
+            dict -> Parsed JSON status response from the pipeline service.
+        """
+        async with httpx.AsyncClient(limits=_CLIENT_LIMITS) as client:
+            response = await client.get(url, headers=headers, timeout=10.0)
+        response.raise_for_status()
+        return response.json()
+
     @override
     async def run_async(self, *, args: dict, tool_context: ToolContext) -> dict:
         """
@@ -213,30 +242,16 @@ class CheckIngestionStatusTool(BaseTool):
         """
         raw_job_id = args.get("job_id")
         logger.info(f"[check_ingestion_status] Invoked with job_id='{raw_job_id}'")
-
         try:
-            # Step 1: Validate input
-            logger.debug(
-                "[check_ingestion_status] Step 1/3: Validating request schema..."
-            )
             request = CheckIngestionStatusRequest(**args)
             logger.debug(
-                f"[check_ingestion_status] Step 1/3: Schema valid. job_id='{request.job_id}'"
+                f"[check_ingestion_status] Request valid — job_id='{request.job_id}'"
             )
-
-            # Step 2: Resolve URL and obtain auth token
             url = f"{AGENT_CONFIG.EKB_PIPELINE_URL.strip('/')}/status/{request.job_id}"
-            logger.debug(f"[check_ingestion_status] Step 2/3: Status URL='{url}'")
-
-            logger.debug(
-                "[check_ingestion_status] Step 2/3: Fetching OIDC identity token..."
+            headers = _get_bearer_headers(
+                AGENT_CONFIG.EKB_PIPELINE_URL, "check_ingestion_status"
             )
-            id_token = get_id_token(AGENT_CONFIG.EKB_PIPELINE_URL)
-            if not id_token:
-                logger.error(
-                    "[check_ingestion_status] Step 2/3: FAILED — could not obtain ID token. "
-                    f"Target audience: '{AGENT_CONFIG.EKB_PIPELINE_URL}'"
-                )
+            if not headers:
                 return CheckIngestionStatusResponse(
                     job_id=request.job_id,
                     status="error",
@@ -244,24 +259,10 @@ class CheckIngestionStatusTool(BaseTool):
                     execution_status="error",
                     execution_message="Authentication failed",
                 ).model_dump()
-            logger.debug("[check_ingestion_status] Step 2/3: ID token obtained.")
 
-            # Step 3: GET status from EKB service
-            headers = {"Authorization": f"Bearer {id_token}"}
-            logger.debug(
-                f"[check_ingestion_status] Step 3/3: GETting status for job_id='{request.job_id}'..."
-            )
-            async with httpx.AsyncClient(limits=_CLIENT_LIMITS) as client:
-                response = await client.get(url, headers=headers, timeout=10.0)
-
-            logger.debug(
-                f"[check_ingestion_status] Step 3/3: Received HTTP {response.status_code} for job_id='{request.job_id}'."
-            )
-            response.raise_for_status()
-            data = response.json()
-            job_status = data.get("status")
+            data = await self._fetch_job_status(url, headers)
             logger.info(
-                f"[check_ingestion_status] Step 3/3: job_id='{request.job_id}' → status='{job_status}'"
+                f"[check_ingestion_status] job_id='{request.job_id}' → status='{data.get('status')}'"
             )
             return CheckIngestionStatusResponse(**data).model_dump()
 
@@ -274,5 +275,5 @@ class CheckIngestionStatusTool(BaseTool):
                 status="error",
                 message=str(e),
                 execution_status="error",
-                execution_message="Internal Error",
+                execution_message=f"Internal Error: {type(e).__name__}: {e}",
             ).model_dump()

--- a/agent/core_agent/tools/kb_tools.py
+++ b/agent/core_agent/tools/kb_tools.py
@@ -14,6 +14,7 @@ from .kb_schemas import (
     CheckIngestionStatusResponse,
 )
 
+# Key for storing pending jobs in session state
 PENDING_INGESTIONS_KEY = "pending_ingestions"
 
 _CLIENT_LIMITS = httpx.Limits(max_keepalive_connections=50, max_connections=100)

--- a/agent/skills/kb-file-ingestion/SKILL.md
+++ b/agent/skills/kb-file-ingestion/SKILL.md
@@ -19,11 +19,12 @@ or similar requests.
 ## Progress Tracker
 Maintain this state throughout the interaction:
 - [ ] Step 1: Identify and validate all uploaded PDF files
-- [ ] Step 2a: Collect shared metadata (single message for all files)
-- [ ] Step 2b: Semantic project validation + deduplication check (per file)
+- [ ] Step 2a: Metadata collection — auto-fill from context if available, otherwise ask in one message
+- [ ] Step 2b: Semantic project validation + deduplication check (per file, run in parallel)
 - [ ] Step 2c: Present confirmation table → handle per-file overrides → await explicit user confirmation
-- [ ] Step 3: Relocate and stamp metadata (parallel — all files simultaneously)
-- [ ] Step 4: Trigger EKB pipeline (parallel — all files simultaneously) + consolidated final summary
+- [ ] Step 3a: Upload files to KB landing zone (all files in parallel)
+- [ ] Step 3b: Stamp metadata on uploaded files (all files in parallel, after 3a completes)
+- [ ] Step 4: Trigger EKB pipeline (all files in parallel) + consolidated final summary
 
 ## Gotchas
 - **GCS URIs**: The agent landing zone is always `gs://ai_agent_landing_zone/`. 
@@ -31,6 +32,7 @@ Maintain this state throughout the interaction:
 - **Project IDs**: In BigQuery, `project_id` is case-sensitive in some operations but should be checked case-insensitively for duplicates.
 - **Job IDs**: Always return the `job_id` from the pipeline response to the user as a confirmation.
 - **Proactive Notifications**: The agent core automatically checks pending `job_id`s before every response. You do not need to poll manually; a system update will appear in your history once the job is finished.
+- **Parallelism**: Steps 3a, 3b, and 4 each launch ALL their tool calls at the same time. Never loop one-by-one.
 
 ## Mandatory Workflow
 
@@ -45,7 +47,22 @@ Maintain this state throughout the interaction:
 
 #### 2a — Metadata Collection
 
-**Single file**: Ask for all metadata in one message immediately after Step 1:
+**Auto-fill from context (applies to both single and batch):**
+
+Before asking the user for metadata, check whether you already have project context in the current conversation (e.g., the user mentioned a project name, you retrieved project records earlier, or there is a confirmed `project_id` in the session). If you have enough context to propose values for any of the four metadata fields (Project, Domain, Trust-level, PII Status), pre-fill them and ask the user to confirm rather than asking from scratch:
+
+> "Based on our conversation, I have pre-filled the following metadata. Please confirm or correct any values before I proceed:
+> - **Files**: `<file1.pdf>`, `<file2.pdf>`, …
+> - **Project**: `<inferred_project>` ← *inferred from context*
+> - **Domain**: `<inferred_domain>` ← *inferred from context* (or blank if unknown)
+> - **Trust-level**: `<inferred_trust_level>` ← *inferred from context* (or blank if unknown)
+> - **PII Status**: `<inferred_pii_status>` ← *inferred from context* (or blank if unknown)
+>
+> Is everything correct? If anything needs to change, let me know before I continue."
+
+Only ask the full question below when no context is available.
+
+**No context — Single file**: Ask for all metadata in one message immediately after Step 1:
 
 > "Before publishing the file to the EKB, please provide me the following information:
 > - **Project the file belongs to**:
@@ -53,7 +70,7 @@ Maintain this state throughout the interaction:
 > - **Trust-level**: (`Published` — verified & ready for company-wide use | `WIP` — draft still being refined | `Archived` — historical reference, no longer active)
 > - **PII Status**: Does this document contain any Personally Identifiable Information (names, emails, IDs)?"
 
-**Multiple files (Batch Mode)**: List all detected filenames, then ask for shared metadata in one message:
+**No context — Multiple files (Batch Mode)**: List all detected filenames, then ask for shared metadata in one message:
 
 > "Before publishing those files to the EKB, please provide me the following information:
 > - **Files detected**: `<file1.pdf>`, `<file2.pdf>`, … *(list all)*
@@ -62,9 +79,9 @@ Maintain this state throughout the interaction:
 > - **Trust-level**: (`Published` | `WIP` | `Archived`)
 > - **PII Status**: Do any of these documents contain Personally Identifiable Information (names, emails, IDs)?"
 
-#### 2b — Validation (run for every file)
+#### 2b — Validation (run all checks in parallel for every file simultaneously)
 
-Once the user provides the information, perform the following in sequence:
+Once the user confirms or provides metadata, launch the following for **all files at the same time**:
 
 1.  **Semantic Project Validation**: Use `ekb_semantic_search(query='<user_input_project_name>')`.
     - If a high-confidence match exists, proceed with that `project_id`.
@@ -97,34 +114,48 @@ Or *(multiple files)*:
 - If the user specifies per-file overrides, update the plan for those files, re-display the corrected table, and ask for final confirmation before continuing.
 - Do NOT proceed to Step 3 until the user explicitly confirms.
 
-### Step 3: Relocation & Stamping *(execute in parallel for all files in the confirmed batch)*
-1.  **Move File**: Use `upload_object` (from GCS MCP) to copy the file using these parameters:
-    - `source_gcs_uri`: The URI identified in Step 1 for this file.
-    - `destination_bucket`: "ag-core-dev-fdx7-kb-landing-zone"
-    - `filename`: The confirmed filename.
-    - `path_inside_bucket`: The confirmed `<project_id>` for this file.
-    - **Note**: The relocation process automatically preserves the source metadata.
-2.  **Stamp Metadata**: Use `update_object_metadata` (GCS) to attach the confirmed metadata for this file. This will be **merged** with existing metadata:
-    ```json
-    {
-      "project": "<project>",
-      "domain": "<domain>",
-      "trust-level": "<trust_level>",
-      "pii_status": "<status>"
-    }
-    ```
+### Step 3a: Upload Files *(all files launched in parallel simultaneously)*
 
-### Step 4: Trigger Pipeline *(execute in parallel for all files in the confirmed batch)*
-1.  Call `trigger_ekb_pipeline(gcs_uri='<destination_uri_returned_in_Step_3>')` for each file simultaneously.
-    - **Note**: This MUST be exactly the same URI returned by the `upload_object` tool for that file.
-2.  **Final Confirmation**: After all files have been processed, provide a single consolidated summary:
-    ```markdown
-    ### Ingestion Started
-    | File | Project | Job ID | Status |
-    |:---:|:---:|:---:|:---:|
-    | <file1.pdf> | <project_id> | <job_id> | <current job status> |
-    | <file2.pdf> | <project_id> | <job_id> | <current job status> |
+Call `upload_object` for **every file at the same time** — do not wait for one to finish before starting the next:
 
-    All documents are being processed and will be available in the KB shortly.
-    ```
-    For a single file, use the original single-entry format instead of the table.
+For each file use:
+- `source_gcs_uri`: The URI identified in Step 1 for this file.
+- `destination_bucket`: "ag-core-dev-fdx7-kb-landing-zone"
+- `filename`: The confirmed filename.
+- `path_inside_bucket`: The confirmed `<project_id>` for this file.
+
+Wait for **all** uploads to complete before proceeding to Step 3b.
+
+### Step 3b: Stamp Metadata *(all files launched in parallel simultaneously)*
+
+Once all uploads from Step 3a have finished, call `update_object_metadata` for **every file at the same time**:
+
+```json
+{
+  "project": "<project>",
+  "domain": "<domain>",
+  "trust-level": "<trust_level>",
+  "pii_status": "<status>"
+}
+```
+
+Wait for **all** metadata stamps to complete before proceeding to Step 4.
+
+### Step 4: Trigger Pipeline *(all files launched in parallel simultaneously)*
+
+Call `trigger_ekb_pipeline(gcs_uri='<destination_uri_returned_in_Step_3a>')` for **every file at the same time** — do not wait for one to finish before starting the next.
+
+- **Note**: The `gcs_uri` MUST be exactly the URI returned by the `upload_object` tool in Step 3a for that file.
+
+**Final Confirmation**: After all pipeline triggers have responded, provide a single consolidated summary:
+
+```markdown
+### Ingestion Started
+| File | Project | Job ID | Status |
+|:---:|:---:|:---:|:---:|
+| <file1.pdf> | <project_id> | <job_id> | <current job status> |
+| <file2.pdf> | <project_id> | <job_id> | <current job status> |
+
+All documents are being processed and will be available in the KB shortly.
+```
+For a single file, use the original single-entry format instead of the table.

--- a/agent/tests/test_kb_tools.py
+++ b/agent/tests/test_kb_tools.py
@@ -109,7 +109,6 @@ class TestTriggerEKBPipelineTool:
         """
         mock_get_token.return_value = "mock-id-token"
 
-        # Each call to httpx.AsyncClient() returns a fresh mock response
         responses = [
             _make_mock_response(200, {"job_id": "job-file-1"}),
             _make_mock_response(200, {"job_id": "job-file-2"}),

--- a/agent/tests/test_kb_tools.py
+++ b/agent/tests/test_kb_tools.py
@@ -207,6 +207,74 @@ class TestTriggerEKBPipelineTool:
         assert result["execution_status"] == "error"
         assert "Internal Error" in result["execution_message"]
 
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_trigger_pipeline_handles_read_timeout(
+        self, mock_async_client_cls, mock_get_token
+    ):
+        """
+        Failure mode: Cloud Run cold-start causes a ReadTimeout.
+        The tool must return execution_status='error' rather than raising,
+        and the message must surface the timeout clearly.
+        """
+        mock_get_token.return_value = "mock-id-token"
+
+        client_mock = MagicMock()
+        client_mock.post = AsyncMock(side_effect=httpx.ReadTimeout(""))
+        async_ctx = MagicMock()
+        async_ctx.__aenter__ = AsyncMock(return_value=client_mock)
+        async_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_async_client_cls.return_value = async_ctx
+
+        tool = TriggerEKBPipelineTool()
+        ctx = MagicMock()
+
+        result = await tool.run_async(
+            args={"gcs_uri": "gs://kb-landing-zone/project/doc.pdf"},
+            tool_context=ctx,
+        )
+
+        assert result["execution_status"] == "error"
+        assert "ReadTimeout" in result["execution_message"]
+
+    @patch("agent.core_agent.tools.kb_tools.get_id_token")
+    @patch("agent.core_agent.tools.kb_tools.httpx.AsyncClient")
+    async def test_trigger_pipeline_timeout_is_at_least_120s(
+        self, mock_async_client_cls, mock_get_token
+    ):
+        """
+        Regression guard: the POST to the EKB pipeline must use a timeout of at
+        least 120 seconds to survive Cloud Run cold starts (which previously caused
+        failures at the 30-second default).
+        """
+        mock_get_token.return_value = "mock-id-token"
+
+        post_mock = AsyncMock(
+            return_value=_make_mock_response(200, {"job_id": "job-timeout-check"})
+        )
+        client_mock = MagicMock()
+        client_mock.post = post_mock
+        async_ctx = MagicMock()
+        async_ctx.__aenter__ = AsyncMock(return_value=client_mock)
+        async_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_async_client_cls.return_value = async_ctx
+
+        tool = TriggerEKBPipelineTool()
+        ctx = MagicMock()
+        ctx.state = {}
+
+        await tool.run_async(
+            args={"gcs_uri": "gs://kb-landing-zone/project/doc.pdf"},
+            tool_context=ctx,
+        )
+
+        _, call_kwargs = post_mock.call_args
+        actual_timeout = call_kwargs.get("timeout", 0)
+        assert actual_timeout >= 120.0, (
+            f"EKB pipeline POST timeout is {actual_timeout}s — must be ≥ 120s "
+            "to survive Cloud Run cold starts"
+        )
+
 
 # ---------------------------------------------------------------------------
 # CheckIngestionStatusTool

--- a/pipelines/enterprise_knowledge_base/app/main.py
+++ b/pipelines/enterprise_knowledge_base/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from fastapi import FastAPI, HTTPException, Request
 from loguru import logger
@@ -9,7 +10,6 @@ from .schemas import (
     JobStatusResponse,
     JobStatus,
 )
-from .config import EKB_CONFIG
 from .jobs import JobService
 from .cloud_tasks.service import CloudTasksService
 from .cloud_tasks.schemas import TaskPayload
@@ -41,8 +41,8 @@ app = FastAPI(
 )
 
 job_service = JobService()
-ekb_pipeline = KBIngestionPipeline(EKB_CONFIG.PROJECT_ID)
 cloud_tasks_service = CloudTasksService()
+ekb_pipeline = KBIngestionPipeline()
 
 
 @app.post("/ingest", response_model=OrchestratorRunResponse)
@@ -63,11 +63,14 @@ async def ingest_document(
     logger.info(f"Received ingestion request for URI: {request.gcs_uri}")
     try:
         filename = request.filename
-        job_id = job_service.create_job(filename)
+        job_id = await asyncio.to_thread(job_service.create_job, filename)
 
         service_url = str(fastapi_req.base_url)
-        cloud_tasks_service.enqueue_ingestion_task(
-            job_id, request.model_dump(), service_url
+        await asyncio.to_thread(
+            cloud_tasks_service.enqueue_ingestion_task,
+            job_id,
+            request.model_dump(),
+            service_url,
         )
 
         return OrchestratorRunResponse(
@@ -106,14 +109,19 @@ async def get_status(job_id: str) -> JobStatusResponse:
 @app.post("/task-handler")
 async def handle_task(payload: TaskPayload) -> dict:
     """
-    Synchronous execution of the pipeline, triggered by Cloud Tasks.
-    This maintains an active HTTP connection so Cloud Run can scale horizontally
-    and allocate full CPU resources.
+    Executes the full pipeline for a single document, triggered by Cloud Tasks.
+    Holds the HTTP connection open until completion so Cloud Tasks can track success or failure.
+
+    Args:
+        payload: TaskPayload -> Contains the job_id and the original ingestion request.
+
+    Returns:
+        dict -> A status dict with key 'status' set to 'success' on completion.
     """
     with logger.contextualize(job_id=payload.job_id):
         logger.info(f"Received Cloud Task for job_id: {payload.job_id}")
         try:
-            result = ekb_pipeline.run(payload.request)
+            result = await asyncio.to_thread(ekb_pipeline.run, payload.request)
 
             # Extract metadata for status update
             metadata = {

--- a/pipelines/enterprise_knowledge_base/app/main.py
+++ b/pipelines/enterprise_knowledge_base/app/main.py
@@ -123,7 +123,6 @@ async def handle_task(payload: TaskPayload) -> dict:
         try:
             result = await asyncio.to_thread(ekb_pipeline.run, payload.request)
 
-            # Extract metadata for status update
             metadata = {
                 "gcs_uri": result.gcs_uri,
                 "chunks_generated": result.chunks_generated,

--- a/pipelines/enterprise_knowledge_base/app/orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/app/orchestrator.py
@@ -1,6 +1,7 @@
 import sys
 from loguru import logger
 
+from .config import EKB_CONFIG
 from .document_classification import ClassificationPipeline
 from .document_classification.config import CLASSIFICATION_CONFIG
 from .rag_ingestion import (
@@ -17,13 +18,9 @@ class KBIngestionPipeline:
     the sequential execution of security classification and semantic indexing.
     """
 
-    def __init__(self, project_id: str):
-        """Initializes the orchestrator with required sub-services.
-
-        Args:
-            project_id: str -> The GCP Project ID for all operations.
-        """
-        self.project_id = project_id
+    def __init__(self) -> None:
+        """Initializes the orchestrator with required sub-services."""
+        self.project_id = EKB_CONFIG.PROJECT_ID
         self.classification_pipeline = ClassificationPipeline()
         self.rag_pipeline = RAGIngestion()
 
@@ -75,16 +72,15 @@ class KBIngestionPipeline:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
+    if len(sys.argv) < 2:
         print(
-            "Usage: uv run python -m pipelines.enterprise_knowledge_base.app.orchestrator <project_id> <gcs_uri>"
+            "Usage: uv run python -m pipelines.enterprise_knowledge_base.app.orchestrator <gcs_uri>"
         )
         sys.exit(1)
 
-    proj_id = sys.argv[1]
-    input_uri = sys.argv[2]
+    input_uri = sys.argv[1]
 
-    pipeline = KBIngestionPipeline(proj_id)
+    pipeline = KBIngestionPipeline()
     run_req = OrchestratorRunRequest(gcs_uri=input_uri)
     response = pipeline.run(run_req)
     print(response.model_dump_json(indent=2))

--- a/pipelines/enterprise_knowledge_base/app/orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/app/orchestrator.py
@@ -35,12 +35,10 @@ class KBIngestionPipeline:
         """
         logger.info(f"Triggering KB Ingestion Pipeline for: {request.gcs_uri}")
 
-        # 1. Execute Classification Pipeline
         logger.info("Step 1: Running Document Classification...")
         class_resp = self.classification_pipeline.run(request.gcs_uri)
         logger.info(f"Classification complete. Domain: {class_resp.final_domain}")
 
-        # 2. Execute end-to-end RAG pipeline
         logger.info(
             f"Step 2: Running RAG Ingestion for {class_resp.final_original_uri}..."
         )

--- a/pipelines/enterprise_knowledge_base/tests/test_orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_orchestrator.py
@@ -17,7 +17,7 @@ def test_orchestrator_run_returns_pipeline_result():
         ),
         patch("pipelines.enterprise_knowledge_base.app.orchestrator.RAGIngestion"),
     ):
-        pipeline = KBIngestionPipeline("test-project")
+        pipeline = KBIngestionPipeline()
 
         # Mock internal pipeline responses
         mock_class_resp = MagicMock()

--- a/terraform/ekb_pipeline_resources/main.tf
+++ b/terraform/ekb_pipeline_resources/main.tf
@@ -59,7 +59,6 @@ module "ekb_pipeline_cloud_run" {
           cpu    = var.ekb_pipeline_cloud_run_cpu
           memory = var.ekb_pipeline_cloud_run_memory
         }
-        cpu_idle = false
       }
     }
   }

--- a/terraform/ekb_pipeline_resources/main.tf
+++ b/terraform/ekb_pipeline_resources/main.tf
@@ -59,6 +59,7 @@ module "ekb_pipeline_cloud_run" {
           cpu    = var.ekb_pipeline_cloud_run_cpu
           memory = var.ekb_pipeline_cloud_run_memory
         }
+        cpu_idle = false
       }
     }
   }
@@ -66,6 +67,7 @@ module "ekb_pipeline_cloud_run" {
   service_config = {
     timeout = "3600s"
     scaling = {
+      min_instance_count = 1
       max_instance_count = 100
     }
   }

--- a/terraform/ekb_pipeline_resources/variables.tf
+++ b/terraform/ekb_pipeline_resources/variables.tf
@@ -74,11 +74,11 @@ variable "ekb_pipeline_cloud_run_env" {
 variable "ekb_pipeline_cloud_run_cpu" {
   description = "The number of vCPUs to allocate to the Cloud Run container."
   type        = string
-  default     = "2"
+  default     = "8"
 }
 
 variable "ekb_pipeline_cloud_run_memory" {
   description = "The amount of memory to allocate to the Cloud Run container."
   type        = string
-  default     = "8Gi"
+  default     = "16Gi"
 }


### PR DESCRIPTION
## Problem

The `trigger_ekb_pipeline` tool was failing with `httpx.ReadTimeout` after exactly 30 seconds when calling the EKB pipeline `/ingest` endpoint. Root cause: Cloud Run cold starts (the instance was scaling to zero between uses) took >30s to initialise the heavy GCP SDK stack, while the agent's HTTP client had a 30-second timeout. Additionally, the pipeline's `/ingest` and `/task-handler` endpoints were calling blocking synchronous functions (BigQuery, Cloud Tasks, pipeline execution) directly inside `async` FastAPI handlers, which serialised all concurrent requests on the event loop.

---

## Changes & Improvements

### Bug Fix — ReadTimeout on `trigger_ekb_pipeline`
- Raised `httpx` POST timeout from `30s → 120s` on the `/ingest` call to survive cold starts
- Exception type now surfaces in `execution_message` (e.g. `"Internal Error: ReadTimeout: "`) instead of being silently swallowed as `"Internal Error: "`

### Async Concurrency — Parallel ingestion
- Wrapped all blocking calls in `asyncio.to_thread()` across both handlers:
  - `/ingest`: `job_service.create_job()` (BigQuery `load_job.result()`) and `cloud_tasks_service.enqueue_ingestion_task()` (gRPC)
  - `/task-handler`: `ekb_pipeline.run()` (full classification + RAG pipeline)
- With these changes, 30 parallel `/ingest` triggers now return job IDs concurrently instead of serialising on the event loop

### Infrastructure — Cloud Run sizing for ~30 parallel 25MB PDFs
- `min_instance_count = 1` — keeps one instance always warm, eliminating cold starts permanently
- `cpu_idle = false` — prevents CPU throttling between requests so background threads are never starved
- CPU `2 → 8 vCPU` and Memory `8Gi → 16Gi` — sized for ~30 concurrent pipeline runs (`30 × ~200MB/job + overhead + 30% buffer`)

### Refactor — `KBIngestionPipeline` instantiation
- `KBIngestionPipeline.__init__` now reads `EKB_CONFIG.PROJECT_ID` internally (no constructor argument), consistent with `JobService` and `CloudTasksService`
- Instantiated as a module-level singleton alongside the other services

### Refactor — `kb_tools.py` (coding standards)
- Extracted `_get_bearer_headers()` as a module-level helper — removes duplicated auth logic from both tools
- Extracted `_post_to_ingest()`, `_store_pending_job()`, `_fetch_job_status()` as private methods
- All functions now under the 50-line limit per coding guidelines
- `CheckIngestionStatusTool` except block now includes exception type in `execution_message`, consistent with `TriggerEKBPipelineTool`

### Skill update — `kb-file-ingestion`
- Steps 3 and 4 split into explicit parallel phases: **3a** upload all files simultaneously → **3b** stamp metadata simultaneously → **4** trigger pipeline simultaneously
- New auto-fill behaviour: when the agent already has project context from the conversation, it pre-populates metadata fields and asks the user to confirm rather than asking from scratch

### Regression tests
- `test_trigger_pipeline_handles_read_timeout` — verifies `ReadTimeout` is caught and surfaced in `execution_message`
- `test_trigger_pipeline_timeout_is_at_least_120s` — captures the actual `timeout=` kwarg passed to `httpx` and asserts ≥ 120s; fails explicitly if the timeout is ever reverted

---

## Test Plan

- [x] `make run-ekb-tests` — 18/18 passed
- [x] `agent/tests/test_kb_tools.py` — 14/14 passed (includes 2 new regression tests)
- [x] Pre-commit hooks (ruff, ruff-format, terraform fmt) — all passed