### PR TITLE
MCP Servers / BigQuery - Create a new ekb_keyword_search for deterministic search of files

### DIFF
--- a/agent/core_agent/config/agent_settings.py
+++ b/agent/core_agent/config/agent_settings.py
@@ -260,8 +260,18 @@ class ResearchAgentConfig(BaseAgentConfig):
             - **Research, knowledge discovery, EKB queries, document search, or project/company intelligence** → load the `knowledge-discovery` skill.
             - **Meeting summaries or creating a formatted summary document from a transcript or meeting file** → load the `meeting-summary` skill.
 
+            ### SEARCH-FIRST PRINCIPLE
+            **Never respond with "I don't know", "I have no information about", "I can't find", or any equivalent without first executing the full search protocol.**
+
+            If the answer is not present in the current conversation context:
+            1. Load the `knowledge-discovery` skill.
+            2. Execute the full corresponding protocol (Targeted or Discovery Mode).
+            3. Only after exhausting all protocol steps — including Cross-Mode Fallback and Final Escalation — may you conclude that no information was found.
+
+            This rule applies unconditionally to every research query, not only follow-ups.
+
             ### CORE PRINCIPLES
-            1. **Strict Factuality**: NEVER invent information. If data is not found, state it clearly: "I could not find information regarding X."
+            1. **Strict Factuality**: NEVER invent information. Only after the full search protocol has been exhausted may you state that information was not found.
             2. **Clean Output**: NEVER expose internal identifiers (IDs, hashes, raw GCS URIs, UUIDs). Use human-readable names only.
             3. **Attribution**: If the response draws from specific files, documents, or calendar events, close with a `## References` Markdown table (columns: Source, Filename, Owner, Created at / Last Update). If no referenceable source was used, omit this section entirely. Format is defined in the `knowledge-discovery` skill.
 

--- a/agent/skills/knowledge-discovery/SKILL.md
+++ b/agent/skills/knowledge-discovery/SKILL.md
@@ -37,26 +37,57 @@ Before any retrieval, classify the user's request into one of two modes:
 - "What do we know about company Y?"
 - "Find all documents related to Z"
 - "Summarize everything we have on this topic"
+- "Give me all the projects that are related with the technology X"
+- "Tell me all the projects related to the specific sector Y"
 → Cast a wide net across all sources. Synthesize across EKB, Calendar, BQ, and Drive.
 
 ---
 
 ## Targeted Mode Protocol
 
-### Wave 1 — Broad Semantic Discovery
-Call `ekb_semantic_search` with the following parameters only:
+### Wave 1 — Broad Semantic + Keyword Discovery
+Run both calls simultaneously:
+
+**1a. Semantic Search** — `ekb_semantic_search`:
 - `project_id`: `"ag-core-dev-fdx7"` *(always)*
 - `query`: user's keywords or document name — strip intent words (`"give me"`, `"what is"`, `"duration"`, `"status"`, `"date"`, `"summary"`)
 - `top_k`: `15`
 
-Do NOT include `filename`, `domain`, `project_filter`, or `trust_level` in Wave 1.
+Do NOT include `filename`, `domain`, `project_filter`, or `trust_level`.
 
-From every result, extract and store: `filename`, `gcs_uri`, `chunk_data`, `document_summary`, `domain`.
+**1b. Keyword Search** — `ekb_keyword_search`:
+- `project_id`: `"ag-core-dev-fdx7"` *(always)*
+- `keyword`: the primary entity from the user's query — a technology name, sector, company, or person. Strip all intent words and keep only a single word (e.g., `"React"`, `"healthcare"`, `"banking"`, `"Acme"`).
 
-**If Wave 1 returns zero results:** skip Wave 2 and GCS Long Context. Proceed immediately to the Calendar Search Protocol + Drive Search Protocol running in parallel.
+**After both complete — merge and store:**
+- Build a unified file pool: combine all `filename` values from both results, deduplicated.
+- From semantic results, also extract and store: `gcs_uri`, `chunk_data`, `document_summary`, `domain`.
+- From keyword results, also extract and store: `gcs_uri`, `uploader_email`, `description`, `project_id`.
+- Files that appear in both results are the highest-confidence anchors and must be ranked first for Wave 2.
+
+**Zero-result fallback rules:**
+- Both return zero → skip Wave 2 and GCS Long Context. Proceed immediately to Calendar Search Protocol + Drive Search Protocol in parallel.
+- Only `ekb_semantic_search` returns zero → use keyword search results as the sole anchor pool and proceed to Wave 2 normally.
+- Only `ekb_keyword_search` returns zero → proceed to Wave 2 using semantic results only.
+
+### Wave 1.5 — Focused Semantic Search on Keyword-Identified Files
+*(Run immediately after Wave 1 completes. Only if `ekb_keyword_search` returned results.)*
+
+For every file returned by `ekb_keyword_search`, launch one `ekb_semantic_search` call. Run all simultaneously:
+- `project_id`: `"ag-core-dev-fdx7"` *(always)*
+- `query`: the user's specific final information need — articulate the exact answer being sought, not the user's raw phrasing (e.g., for "give me React projects", use "React project name, client, deliverables, and outcomes")
+- `filename`: exact verbatim value from the `ekb_keyword_search` result `filename` field — never paraphrase
+- `top_k`: `10`
+
+Merge the returned chunks into the unified file pool from Wave 1.
+
+**Hard Rules:**
+- Maximum 10 parallel calls. If `ekb_keyword_search` returned more than 10 files, take the first 10.
+- `filename` MUST come verbatim from an `ekb_keyword_search` result in this session.
+- Files searched here must NOT be re-searched in Wave 2.
 
 ### Wave 2 — Per-File Focused Search (only if Wave 1 returned results)
-Select the top 3 most relevant files from Wave 1, ranked by ascending cosine distance. For each, launch one `ekb_semantic_search` call. Run all simultaneously:
+Select the top 3 most relevant files from Wave 1, ranked by ascending cosine distance, that were NOT already covered in Wave 1.5. For each, launch one `ekb_semantic_search` call. Run all simultaneously:
 - `project_id`: `"ag-core-dev-fdx7"` *(always)*
 - `query`: the user's actual information need — what they want to know, not the filename
 - `filename`: exact verbatim value from the `filename` field of a Wave 1 result — never paraphrase or rewrite
@@ -88,23 +119,41 @@ Follow the **DRIVE SEARCH PROTOCOL** defined in the system prompt using keywords
 ## Discovery Mode Protocol
 
 ### Phase 1: Contextual Anchoring (The Hook)
-1. **Semantic Search**: Call `ekb_semantic_search` with the following parameters only:
+1. **Parallel Search**: Run both calls simultaneously:
+
+   **1a. Semantic Search** — `ekb_semantic_search`:
    - `project_id`: `"ag-core-dev-fdx7"` *(always)*
    - `query`: user's natural language question
    - `top_k`: `10`
 
-   Never add `filename`, `domain`, `project_filter`, or `trust_level` in Phase 1.
+   Never add `filename`, `domain`, `project_filter`, or `trust_level`.
 
-2. **Anchor Extraction**: Build a "Context Graph" from the results:
-   - **Identities**: `filename`, `gcs_uri`, `document_summary`.
-   - **Context**: `document_summary` / `description` — key for generating Phase 2 Drive keywords.
+   **1b. Keyword Search** — `ekb_keyword_search`:
+   - `project_id`: `"ag-core-dev-fdx7"` *(always)*
+   - `keyword`: the primary entity from the user's query — a technology name, sector, company, or person. Strip all intent words and keep only a single word (e.g., `"React"`, `"healthcare"`, `"banking"`, `"Acme"`).
+
+2. **Anchor Extraction**: Build a "Context Graph" from the merged results of both calls:
+   - **Identities**: `filename`, `gcs_uri`, `document_summary` / `description`.
+   - **Context**: `description` — key for generating Phase 2 Drive keywords.
    - **Entities**: company names (clients/partners), technologies, technical stacks.
-   - **Relational Mapping**: map project names to their associated companies and tech stacks — use these as primary anchors for Phase 2 Drive and Calendar searches.
+   - **Relational Mapping**: map project names (`project_id`) to their associated companies and tech stacks — use these as primary anchors for Phase 2 Drive and Calendar searches.
    - **People**: `uploader_email` and stakeholders mentioned in summaries.
    - **Locations**: `gcs_uri` values (for GCS deep-dive in Phase 3 Level 1).
 
-3. **Expansion**: If results are narrow, broaden using extracted entities before moving to Phase 2.
-   - **Zero-Result Fallback**: If `ekb_semantic_search` returns no results, extract keywords directly from the user's original prompt (company names, project names, technologies, dates, people) and use those as Phase 2 anchors. Skip Phase 2b (no BQ project context to anchor against).
+3. **Focused Keyword-File Search**: Immediately after Anchor Extraction, for every file returned by `ekb_keyword_search`, launch one `ekb_semantic_search` call. Run all simultaneously:
+   - `project_id`: `"ag-core-dev-fdx7"` *(always)*
+   - `query`: the user's specific final information need — articulate the exact answer being sought, not the raw question
+   - `filename`: exact verbatim value from an `ekb_keyword_search` result `filename` field — never paraphrase
+   - `top_k`: `10`
+
+   Merge the returned chunks into the Context Graph. Files searched here must NOT be re-searched in Phase 3 Level 1.
+
+   **Hard Rules:**
+   - Maximum 10 parallel calls. If `ekb_keyword_search` returned more than 10 files, take the first 10.
+
+4. **Expansion**: If results are narrow, broaden using extracted entities before moving to Phase 2.
+   - **Zero-Result Fallback**: If both searches return no results, extract keywords directly from the user's original prompt (company names, project names, technologies, dates, people) and use those as Phase 2 anchors. Skip Phase 2b (no BQ project context to anchor against).
+   - If only one of the two searches returns results, use those results as the sole anchor pool and proceed normally.
 
 ### Phase 2: Parallel Context Acquisition (Broad Search)
 Launch all the following simultaneously. *Efficiency Rule: never repeat the same tool call with the same parameters in the same session.*
@@ -118,7 +167,7 @@ Launch all the following simultaneously. *Efficiency Rule: never repeat the same
 ### Phase 3: Synthesis & Targeted Deep Dive (Escalation Path)
 
 **Level 1: EKB Deep-Dive (GCS)**
-For the top 3 high-relevance `gcs_uri` values from Phase 1, run in parallel (following the **GCS FILE READING RULE** from the system prompt):
+For the top 3 high-relevance `gcs_uri` values from Phase 1 that were NOT already covered in Phase 1 step 3, run in parallel (following the **GCS FILE READING RULE** from the system prompt):
 1. Parse each `gcs_uri` → `bucket_name` (everything between `gs://` and the first `/`) and `object_name` (everything after).
 2. `read_object(bucket_name=<bucket_name>, object_name=<object_name>)` → get `mime_type`.
 3. `import_gcs_to_artifact(gcs_uri=<gcs_uri>, mime_type=<mime_type>)`.
@@ -145,7 +194,7 @@ Produce the standard output. Write `No information found` under any section wher
 If Targeted Mode has exhausted all steps without finding the answer, continue with Discovery Mode's unique steps — skipping any tool calls already made:
 - Run Phase 2b BQ `documents_metadata` query if not already executed.
 - Re-run Drive search with full keyword decomposition if the entity map differs meaningfully from keywords already used. Do not repeat identical `list_files` calls.
-- Do NOT repeat `ekb_semantic_search`, `get_current_time`, or `list_calendar_events` calls already made.
+- Do NOT repeat `ekb_semantic_search`, `ekb_keyword_search`, `get_current_time`, or `list_calendar_events` calls already made.
 
 **Discovery → Targeted Fallback:**
 If Discovery Mode has exhausted all phases (Phase 1 through Level 4) without finding the answer, run Targeted Mode's unique steps — skipping any tool calls already made:

--- a/mcp_servers/big_query/app/bq_client.py
+++ b/mcp_servers/big_query/app/bq_client.py
@@ -8,7 +8,7 @@ from google.cloud.exceptions import GoogleCloudError, NotFound
 from google.oauth2.credentials import Credentials
 
 from .config import BIGQUERY_API_CONFIG, BIGQUERY_AUTH_CONFIG
-from .schemas import AuthenticationError, SemanticSearchRequest
+from .schemas import AuthenticationError, KeywordSearchRequest, SemanticSearchRequest
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -352,6 +352,60 @@ class BigQueryManager:
         except Exception as e:
             logger.error(f"Error performing semantic search: {e}")
             raise ValueError(f"Error performing semantic search: {e}")
+
+    def keyword_search(self, request: KeywordSearchRequest) -> List[Dict[str, Any]]:
+        """
+        Performs a deterministic keyword search against knowledge base chunks using CONTAINS_SUBSTR.
+        Returns distinct filenames and project names for all chunks containing the keyword.
+
+        Args:
+            request: KeywordSearchRequest -> Structured request containing project_id and a single keyword.
+
+        Returns:
+            List[Dict[str, Any]] -> A list of dicts with 'filename' and 'project_id' keys.
+        """
+        query = """
+        SELECT DISTINCT
+          m.gcs_uri,
+          m.uploader_email,
+          m.description,
+          c.filename,
+          m.project_id
+        FROM `knowledge_base.documents_chunks` c
+        JOIN `knowledge_base.documents_metadata` m ON c.document_id = m.document_id
+        WHERE m.latest = TRUE
+          AND CONTAINS_SUBSTR(c.chunk_data, @keyword)
+        """
+
+        query_params = [
+            bigquery.ScalarQueryParameter("keyword", "STRING", request.keyword),
+        ]
+
+        try:
+            job_config = bigquery.QueryJobConfig(query_parameters=query_params)
+            query_job = self.client.query(
+                query, project=request.project_id, job_config=job_config
+            )
+            results = query_job.result()
+
+            output = [dict(row) for row in results]
+
+            def make_serializable(obj):
+                if isinstance(obj, dict):
+                    return {k: make_serializable(v) for k, v in obj.items()}
+                elif isinstance(obj, list):
+                    return [make_serializable(v) for v in obj]
+                else:
+                    try:
+                        json.dumps(obj)
+                        return obj
+                    except (TypeError, ValueError):
+                        return str(obj)
+
+            return make_serializable(output)
+        except Exception as e:
+            logger.error(f"Error performing keyword search: {e}")
+            raise ValueError(f"Error performing keyword search: {e}")
 
 
 def build_bq_credentials(

--- a/mcp_servers/big_query/app/mcp_server.py
+++ b/mcp_servers/big_query/app/mcp_server.py
@@ -28,6 +28,8 @@ from .schemas import (
     AddRowsResponse,
     ExecuteQueryRequest,
     ExecuteQueryResponse,
+    KeywordSearchRequest,
+    KeywordSearchResponse,
     SemanticSearchRequest,
     SemanticSearchResponse,
 )
@@ -411,6 +413,39 @@ async def ekb_semantic_search(request: SemanticSearchRequest) -> SemanticSearchR
         )
     except Exception as e:
         return SemanticSearchResponse(
+            results=[],
+            execution_status="error",
+            execution_message=_format_execution_error(e),
+        )
+
+
+@mcp.tool()
+async def ekb_keyword_search(request: KeywordSearchRequest) -> KeywordSearchResponse:
+    """
+    Performs a deterministic keyword search against the Enterprise Knowledge Base chunks.
+    Returns distinct filenames and project names for all documents containing the keyword.
+    Args:
+        request (KeywordSearchRequest): Structured request containing project_id and a single keyword.
+    Returns:
+        KeywordSearchResponse: Distinct filenames and project names matching the keyword.
+    """
+    logger.info(f"Tool call: ekb_keyword_search(keyword={request.keyword})")
+    try:
+        bq_manager = _make_bq_manager()
+        results = await asyncio.to_thread(bq_manager.keyword_search, request)
+        return KeywordSearchResponse(
+            results=results,
+            execution_status="success",
+            execution_message=f"Keyword search completed successfully, returned {len(results)} distinct documents.",
+        )
+    except AuthenticationError as e:
+        return KeywordSearchResponse(
+            results=[],
+            execution_status="error",
+            execution_message=f"Authentication Error: {e}",
+        )
+    except Exception as e:
+        return KeywordSearchResponse(
             results=[],
             execution_status="error",
             execution_message=_format_execution_error(e),

--- a/mcp_servers/big_query/app/schemas.py
+++ b/mcp_servers/big_query/app/schemas.py
@@ -246,3 +246,27 @@ class SemanticSearchResponse(BaseResponse):
     """
 
     results: ROWS
+
+
+class KeywordSearchRequest(BaseModel):
+    """
+    Request model for a deterministic keyword search against knowledge base chunks.
+    """
+
+    project_id: PROJECT_ID
+    keyword: Annotated[
+        str,
+        Field(
+            description="Single keyword to search for using case-insensitive matching.",
+            min_length=1,
+            max_length=200,
+        ),
+    ]
+
+
+class KeywordSearchResponse(BaseResponse):
+    """
+    Response model for keyword search returning distinct filenames and project names.
+    """
+
+    results: ROWS

--- a/mcp_servers/big_query/tests/test_bq_client.py
+++ b/mcp_servers/big_query/tests/test_bq_client.py
@@ -179,6 +179,86 @@ def test_build_bq_credentials_from_access_token(mock_credentials, mock_validate)
     )
 
 
+def test_keyword_search_happy_path(mock_client):
+    """
+    Tests that keyword_search returns distinct filenames and project names for a matching keyword.
+    Implementation: Mocks the BigQuery query job to return two rows and verifies the query uses
+    CONTAINS_SUBSTR against documents_chunks with the correct parameterized keyword.
+    """
+    manager = BigQueryManager(creds=MagicMock())
+    mock_job = MagicMock()
+    mock_rows = [
+        {
+            "gcs_uri": "gs://bucket/doc1.pdf",
+            "uploader_email": "user@example.com",
+            "description": "Alpha project overview",
+            "filename": "doc1.pdf",
+            "project_id": "Alpha Project",
+        },
+        {
+            "gcs_uri": "gs://bucket/doc2.pdf",
+            "uploader_email": "other@example.com",
+            "description": "Beta project overview",
+            "filename": "doc2.pdf",
+            "project_id": "Beta Project",
+        },
+    ]
+    mock_job.result.return_value = mock_rows
+    manager.client.query.return_value = mock_job
+
+    from mcp_servers.big_query.app.schemas import KeywordSearchRequest, AvailableProject
+
+    request = KeywordSearchRequest(project_id=AvailableProject.DEV, keyword="React")
+    result = manager.keyword_search(request)
+
+    assert result == mock_rows
+    args, kwargs = manager.client.query.call_args
+    query_text = args[0]
+    assert "CONTAINS_SUBSTR" in query_text
+    assert "documents_chunks" in query_text
+    assert "SELECT DISTINCT" in query_text
+    params = {p.name: p.value for p in kwargs["job_config"].query_parameters}
+    assert params["keyword"] == "React"
+
+
+def test_keyword_search_no_results(mock_client):
+    """
+    Tests that keyword_search returns an empty list when no chunks match the given keyword.
+    Implementation: Mocks the query job to return an empty result set and verifies the method
+    handles the zero-result edge case without raising.
+    """
+    manager = BigQueryManager(creds=MagicMock())
+    mock_job = MagicMock()
+    mock_job.result.return_value = []
+    manager.client.query.return_value = mock_job
+
+    from mcp_servers.big_query.app.schemas import KeywordSearchRequest, AvailableProject
+
+    request = KeywordSearchRequest(
+        project_id=AvailableProject.DEV, keyword="nonexistentkeyword123"
+    )
+    result = manager.keyword_search(request)
+
+    assert result == []
+
+
+def test_keyword_search_bq_failure(mock_client):
+    """
+    Tests that keyword_search raises ValueError when BigQuery raises an exception.
+    Implementation: Configures the mock client to raise a generic exception and verifies the
+    method re-raises it as a ValueError with a descriptive message.
+    """
+    manager = BigQueryManager(creds=MagicMock())
+    manager.client.query.side_effect = Exception("BQ connection error")
+
+    from mcp_servers.big_query.app.schemas import KeywordSearchRequest, AvailableProject
+
+    request = KeywordSearchRequest(project_id=AvailableProject.DEV, keyword="React")
+
+    with pytest.raises(ValueError, match="Error performing keyword search"):
+        manager.keyword_search(request)
+
+
 def test_semantic_search(mock_client):
     """
     Tests the semantic search functionality.

--- a/mcp_servers/big_query/tests/test_mcp_server.py
+++ b/mcp_servers/big_query/tests/test_mcp_server.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from mcp_servers.big_query.app.mcp_server import (
     create_dataset,
     create_table,
+    ekb_keyword_search,
     get_table_schema,
     add_rows,
     execute_query,
@@ -15,6 +16,7 @@ from mcp_servers.big_query.app.schemas import (
     GetTableSchemaRequest,
     AddRowsRequest,
     ExecuteQueryRequest,
+    KeywordSearchRequest,
     ListTablesRequest,
     AvailableProject,
 )
@@ -163,6 +165,66 @@ async def test_mcp_execute_query_authorized_user_success(mock_bq_manager):
 
     assert result.execution_status == "success"
     assert result.results == [{"id": 1, "name": "allowed"}]
+
+
+@pytest.mark.asyncio
+async def test_mcp_ekb_keyword_search_success(mock_bq_manager):
+    """
+    Tests the successful execution of the ekb_keyword_search MCP tool.
+    Implementation: Mocks keyword_search to return two distinct rows and verifies the tool
+    returns a success status with the expected results list.
+    """
+    mock_bq_manager.keyword_search.return_value = [
+        {
+            "gcs_uri": "gs://bucket/report.pdf",
+            "uploader_email": "user@example.com",
+            "description": "Alpha project report",
+            "filename": "report.pdf",
+            "project_id": "Alpha Project",
+        },
+        {
+            "gcs_uri": "gs://bucket/spec.pdf",
+            "uploader_email": "other@example.com",
+            "description": "Beta project spec",
+            "filename": "spec.pdf",
+            "project_id": "Beta Project",
+        },
+    ]
+    req = KeywordSearchRequest(project_id=AvailableProject.DEV, keyword="kubernetes")
+
+    result = await ekb_keyword_search(req)
+
+    assert result.execution_status == "success"
+    assert len(result.results) == 2
+    assert result.results[0]["filename"] == "report.pdf"
+    mock_bq_manager.keyword_search.assert_called_once_with(req)
+
+
+@pytest.mark.asyncio
+async def test_mcp_ekb_keyword_search_empty_keyword_validation_error():
+    """
+    Tests that KeywordSearchRequest rejects an empty string keyword at schema validation time.
+    Implementation: Attempts to instantiate the request with an empty keyword and asserts
+    Pydantic raises a ValidationError before any tool execution occurs.
+    """
+    with pytest.raises(ValidationError):
+        KeywordSearchRequest(project_id=AvailableProject.DEV, keyword="")
+
+
+@pytest.mark.asyncio
+async def test_mcp_ekb_keyword_search_bq_error(mock_bq_manager):
+    """
+    Tests that ekb_keyword_search returns an error status when the underlying BQ call raises.
+    Implementation: Configures keyword_search to raise a generic exception and verifies the
+    tool wraps it in an error response rather than propagating the exception.
+    """
+    mock_bq_manager.keyword_search.side_effect = Exception("BQ failure")
+    req = KeywordSearchRequest(project_id=AvailableProject.DEV, keyword="react")
+
+    result = await ekb_keyword_search(req)
+
+    assert result.execution_status == "error"
+    assert "BQ failure" in result.execution_message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Semantic search is good for giving specific information, nevertheless, it might bury documents with valuable information when too many files are related to the search, or when a very broad search is made.

For example, the user could ask: "Tell me how many projects are related to Apigee", if a project contains multiple files related to Apigee, the semantic search most probably return chunks related to a single project, which would guide the agent to the conclusion that there is only one project that implements it.

Using the ekb_keyword_search solves this problem by making a deterministic search based on a SQL query using a hard search by keyword. This returns the total files (and its metadata, like the project each file belongs to) that contains Apigee on it (it takes advantage of the chunks generated during the chunking of the data).

So that, this new tool will help to avoid buring files that are related to the topic, but that It cannot be obtained through a semantic search. This allows the agent to get a more detail research, so it returns better responses in general (for wild and specific requests).

This new tool in the MCP of BQ is integrated with the research Skill, making the agent to find answers faster