### PR TITLE
MCP Servers/ BigQuery - Return ingestion dates on ekb tools

### DIFF
--- a/mcp_servers/big_query/app/bq_client.py
+++ b/mcp_servers/big_query/app/bq_client.py
@@ -372,7 +372,9 @@ class BigQueryManager:
           m.uploader_email,
           m.description,
           c.filename,
-          m.project_id
+          m.project_id,
+          m.ingested_at
+
         FROM `knowledge_base.documents_chunks` c
         JOIN `knowledge_base.documents_metadata` m ON c.document_id = m.document_id
         WHERE m.latest = TRUE

--- a/mcp_servers/big_query/app/bq_client.py
+++ b/mcp_servers/big_query/app/bq_client.py
@@ -281,7 +281,9 @@ class BigQueryManager:
           m.project_id,
           m.uploader_email,
           m.description AS document_summary,
-          v.distance
+          v.distance,
+          m.ingested_at
+     
         FROM VECTOR_SEARCH(
           TABLE `knowledge_base.documents_chunks`,
           'embedding',


### PR DESCRIPTION
Currently, everytime the agent get data from the EKB, mainly from the metadata and chunks stored in BQ, it does not know when the file was ingested, so it cannot fill the section of "created_at/last_update_at", in the reference section of its outputs, this PR fixes that by only including the ingested_at column on those queries