### PR TITLE
EKB Ingestion Pipeline/Fix BQ 423 Error

### DIFF
--- a/pipelines/enterprise_knowledge_base/app/document_classification/pipeline.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/pipeline.py
@@ -104,6 +104,11 @@ class ClassificationPipeline:
                 or routing_resp.final_original_uri,
                 final_security_tier=llm_resp.final_classification_tier,
                 final_domain=llm_resp.final_domain,
+                sanitized_landing_uri=(
+                    sanitized_landing_uri
+                    if sanitized_landing_uri != landing_zone_original_uri
+                    else None
+                ),
             )
 
         except Exception as e:
@@ -314,18 +319,34 @@ class ClassificationPipeline:
             final_sanitized_uri = f"{dest_base}{sanitized_filename}"
             self.gcs.copy_blob(request.sanitized_landing_uri, final_sanitized_uri)
 
-        # 3. Cleanup Landing Zone
-        self.gcs.delete_blob(request.original_landing_uri)
-        if (
-            request.sanitized_landing_uri
-            and request.sanitized_landing_uri != request.original_landing_uri
-        ):
-            self.gcs.delete_blob(request.sanitized_landing_uri)
-
         return FileRoutingResponse(
             final_original_uri=final_original_uri,
             final_sanitized_uri=final_sanitized_uri,
         )
+
+    def cleanup_landing_zone(
+        self, original_uri: str, sanitized_uri: Optional[str] = None
+    ) -> None:
+        """Deletes the original and masked files from the landing zone.
+
+        Called only after all pipeline steps (classification + RAG) succeed, so
+        that any earlier failure leaves the files in place for a clean retry.
+
+        Args:
+            original_uri (str): Landing zone URI of the original document.
+            sanitized_uri (Optional[str]): Landing zone URI of the masked file, if one was created.
+
+        Returns:
+            None
+        """
+        logger.info(f"Cleaning up landing zone for: {original_uri}")
+        for uri in filter(None, [original_uri, sanitized_uri]):
+            try:
+                self.gcs.delete_blob(uri)
+            except Exception as e:
+                logger.warning(
+                    f"Landing zone cleanup failed for {uri} (non-fatal): {e}"
+                )
 
     def ingest_metadata_bq(self, request: IngestMetadataBQRequest) -> bool:
         """Persists the document metadata into BQ with versioning logic.

--- a/pipelines/enterprise_knowledge_base/app/document_classification/pipeline.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/pipeline.py
@@ -333,8 +333,8 @@ class ClassificationPipeline:
         that any earlier failure leaves the files in place for a clean retry.
 
         Args:
-            original_uri (str): Landing zone URI of the original document.
-            sanitized_uri (Optional[str]): Landing zone URI of the masked file, if one was created.
+            original_uri: str -> Landing zone URI of the original document.
+            sanitized_uri: Optional[str] -> Landing zone URI of the masked file, if one was created.
 
         Returns:
             None

--- a/pipelines/enterprise_knowledge_base/app/document_classification/schemas.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/schemas.py
@@ -62,3 +62,10 @@ class RunResponse(BaseModel):
         int, Field(description="The definitive security tier.")
     ]
     final_domain: Annotated[str, Field(description="The validated target domain.")]
+    sanitized_landing_uri: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Landing zone URI of the masked file, if masking occurred. Used for deferred cleanup.",
+        ),
+    ]

--- a/pipelines/enterprise_knowledge_base/app/orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/app/orchestrator.py
@@ -48,6 +48,11 @@ class KBIngestionPipeline:
         )
         ingest_resp = self.rag_pipeline.run(ingest_req)
 
+        # Delete from landing zone only after both classification and RAG succeed.
+        self.classification_pipeline.cleanup_landing_zone(
+            request.gcs_uri, class_resp.sanitized_landing_uri
+        )
+
         if "SUCCESS" in ingest_resp.execution_status:
             logger.success(
                 f"Pipeline finished successfully. Chunks: {ingest_resp.chunk_count}"

--- a/pipelines/enterprise_knowledge_base/app/rag_ingestion/pipeline.py
+++ b/pipelines/enterprise_knowledge_base/app/rag_ingestion/pipeline.py
@@ -1,3 +1,4 @@
+import random
 import time
 import unicodedata
 import uuid
@@ -432,13 +433,26 @@ class RAGIngestion:
             source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
         )
 
-        try:
-            job = self.bq_client.load_table_from_json(
-                json_rows, self.table_id, job_config=job_config
-            )
-            job.result()
-        except Exception as e:
-            raise RuntimeError(f"BigQuery batch load failed: {str(e)}")
+        max_retries = 3
+        for attempt in range(max_retries):
+            try:
+                job = self.bq_client.load_table_from_json(
+                    json_rows, self.table_id, job_config=job_config
+                )
+                job.result()
+                return
+            except Exception as e:
+                is_rate_limit = "429" in str(e) or "rateLimitExceeded" in str(e)
+                if attempt == max_retries - 1 or not is_rate_limit:
+                    raise RuntimeError(f"BigQuery batch load failed: {str(e)}")
+                wait_time = 5 * (2**attempt) + random.uniform(
+                    0, 3
+                )  # 5–8s, 10–13s, 20–23s
+                logger.warning(
+                    f"BQ table.write rate limit on attempt {attempt + 1}, "
+                    f"retrying in {wait_time:.1f}s..."
+                )
+                time.sleep(wait_time)
 
     def _copy_to_staging(self, source_uri: str, destination_uri: str) -> None:
         """Copies a document from its source (Domain) to the RAG Staging bucket.

--- a/pipelines/enterprise_knowledge_base/app/rag_ingestion/tests/test_pipeline.py
+++ b/pipelines/enterprise_knowledge_base/app/rag_ingestion/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline import RAGIngestion
 from pipelines.enterprise_knowledge_base.app.rag_ingestion.schemas import DocumentChunk
@@ -6,13 +7,19 @@ from pipelines.enterprise_knowledge_base.app.rag_ingestion.schemas import Docume
 
 @pytest.fixture
 def rag_svc():
-    with patch("google.cloud.storage.Client"), patch("google.cloud.bigquery.Client"):
-        return RAGIngestion()
+    with (
+        patch(
+            "pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline.RAGIngestion.storage_client"
+        ),
+        patch(
+            "pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline.RAGIngestion.bq_client"
+        ),
+    ):
+        yield RAGIngestion()
 
 
 def test_chunking_character_limit(rag_svc):
     """Verifies that chunks are strictly under the 1024 character limit."""
-    # Create a long text
     long_text = "Word " * 500  # ~2500 characters
 
     chunks = rag_svc.text_splitter.split_text(long_text)
@@ -26,25 +33,22 @@ def test_pure_content_query_generation(rag_svc):
     """Verifies that the embedding query vectorizes pure content without metadata joins."""
     request = MagicMock()
     request.gcs_uri = "gs://test/doc.pdf"
+    request.expected_chunk_count = 0
 
-    # We want to check the 'query' variable inside generate_embeddings
-    # Since it's a local variable, we'll mock bq_client.query and check the call
-    rag_svc.bq_client.query.return_value = MagicMock()
+    mock_job = MagicMock()
+    mock_job.num_dml_affected_rows = 1
+    rag_svc.bq_client.query.return_value = mock_job
 
-    try:
-        rag_svc.generate_embeddings(request)
-    except Exception:
-        pass  # We only care about the call
+    rag_svc.generate_embeddings(request)
 
-    args, kwargs = rag_svc.bq_client.query.call_args
+    args, _ = rag_svc.bq_client.query.call_args_list[0]
     query = args[0]
 
-    # Assertions for Pure Content strategy
     assert "ML.GENERATE_EMBEDDING" in query
     assert "chunk_data AS content" in query
-    assert "LEFT JOIN" not in query  # No metadata join
-    assert "CONCAT" not in query  # No metadata injection
-    assert "NORMALIZE(c.gcs_uri)" in query  # URI safety
+    assert "LEFT JOIN" not in query
+    assert "CONCAT" not in query
+    assert "NORMALIZE(c.gcs_uri)" in query
 
 
 def test_load_job_usage(rag_svc):
@@ -57,15 +61,12 @@ def test_load_job_usage(rag_svc):
             gcs_uri="uri",
             filename="file",
             page_number=1,
+            structural_metadata={"page": 1},
+            created_at=datetime.now(timezone.utc).isoformat(),
         )
     ]
-
-    rag_svc.bq_client.load_table_from_json = MagicMock()
 
     rag_svc._stage_chunks_bq(chunks)
 
     assert rag_svc.bq_client.load_table_from_json.called
-    assert (
-        not hasattr(rag_svc.bq_client, "insert_rows_json")
-        or not rag_svc.bq_client.insert_rows_json.called
-    )
+    assert not rag_svc.bq_client.insert_rows_json.called

--- a/pipelines/enterprise_knowledge_base/tests/test_document_classification.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_document_classification.py
@@ -408,3 +408,53 @@ def test_run_returns_masked_uri_when_sanitized(
         result.final_sanitized_uri
         == "gs://kb-executives/top-secret/strictly-confidential/admin/secret_masked.txt"
     )
+
+
+def test_file_routing_does_not_delete_landing_zone_blobs(pipeline, mock_gcs):
+    """Regression: file_routing must only copy files to the domain bucket, never delete
+    from the landing zone. Deletion is deferred to cleanup_landing_zone after RAG succeeds."""
+    from pipelines.enterprise_knowledge_base.app.document_classification.schemas import (
+        FileRoutingRequest,
+    )
+
+    request = FileRoutingRequest(
+        original_landing_uri="gs://landing/proj/doc.pdf",
+        sanitized_landing_uri="gs://landing/proj/doc_masked.pdf",
+        final_domain="it",
+        final_security_tier=1,
+        project_name="proj",
+        uploader_email="user@example.com",
+    )
+
+    pipeline.file_routing(request)
+
+    mock_gcs.delete_blob.assert_not_called()
+
+
+def test_cleanup_landing_zone_deletes_original_and_sanitized(pipeline, mock_gcs):
+    """Verifies cleanup_landing_zone deletes both the original and masked landing zone files."""
+    original_uri = "gs://landing/proj/doc.pdf"
+    sanitized_uri = "gs://landing/proj/doc_masked.pdf"
+
+    pipeline.cleanup_landing_zone(original_uri, sanitized_uri)
+
+    mock_gcs.delete_blob.assert_any_call(original_uri)
+    mock_gcs.delete_blob.assert_any_call(sanitized_uri)
+    assert mock_gcs.delete_blob.call_count == 2
+
+
+def test_cleanup_landing_zone_skips_sanitized_when_none(pipeline, mock_gcs):
+    """Verifies cleanup_landing_zone only deletes the original when no masked file exists."""
+    original_uri = "gs://landing/proj/doc.pdf"
+
+    pipeline.cleanup_landing_zone(original_uri, None)
+
+    mock_gcs.delete_blob.assert_called_once_with(original_uri)
+
+
+def test_cleanup_landing_zone_is_non_fatal_on_gcs_error(pipeline, mock_gcs):
+    """Verifies cleanup_landing_zone does not raise if GCS deletion fails,
+    so a stale landing zone file never fails an otherwise successful pipeline."""
+    mock_gcs.delete_blob.side_effect = Exception("GCS Error")
+
+    pipeline.cleanup_landing_zone("gs://landing/doc.pdf", None)

--- a/pipelines/enterprise_knowledge_base/tests/test_orchestrator.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_orchestrator.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import MagicMock, patch
 from pipelines.enterprise_knowledge_base.app.orchestrator import KBIngestionPipeline
 from pipelines.enterprise_knowledge_base.app.schemas import (
@@ -47,3 +48,60 @@ def test_orchestrator_run_returns_pipeline_result():
         # if they were required but missing (the root cause of the bug).
         assert not hasattr(result, "job_id")
         assert not hasattr(result, "status")
+
+
+def test_orchestrator_cleanup_called_after_rag_success():
+    """Regression: cleanup_landing_zone must be called only after RAG succeeds."""
+    with (
+        patch(
+            "pipelines.enterprise_knowledge_base.app.orchestrator.ClassificationPipeline"
+        ),
+        patch("pipelines.enterprise_knowledge_base.app.orchestrator.RAGIngestion"),
+    ):
+        pipeline = KBIngestionPipeline()
+
+        mock_class_resp = MagicMock()
+        mock_class_resp.final_original_uri = "gs://kb-it/project/file.pdf"
+        mock_class_resp.final_domain = "it"
+        mock_class_resp.final_security_tier = 1
+        mock_class_resp.sanitized_landing_uri = "gs://landing/file_masked.pdf"
+        pipeline.classification_pipeline.run.return_value = mock_class_resp
+
+        mock_rag_resp = MagicMock()
+        mock_rag_resp.chunk_count = 10
+        mock_rag_resp.execution_status = "SUCCESS"
+        pipeline.rag_pipeline.run.return_value = mock_rag_resp
+
+        request = OrchestratorRunRequest(gcs_uri="gs://landing/file.pdf")
+        pipeline.run(request)
+
+        pipeline.classification_pipeline.cleanup_landing_zone.assert_called_once_with(
+            "gs://landing/file.pdf", "gs://landing/file_masked.pdf"
+        )
+
+
+def test_orchestrator_cleanup_not_called_on_rag_failure():
+    """Regression: cleanup_landing_zone must NOT be called if RAG ingestion fails,
+    so the original file remains in the landing zone for a clean retry."""
+    with (
+        patch(
+            "pipelines.enterprise_knowledge_base.app.orchestrator.ClassificationPipeline"
+        ),
+        patch("pipelines.enterprise_knowledge_base.app.orchestrator.RAGIngestion"),
+    ):
+        pipeline = KBIngestionPipeline()
+
+        mock_class_resp = MagicMock()
+        mock_class_resp.final_original_uri = "gs://kb-it/project/file.pdf"
+        mock_class_resp.final_domain = "it"
+        mock_class_resp.final_security_tier = 1
+        mock_class_resp.sanitized_landing_uri = None
+        pipeline.classification_pipeline.run.return_value = mock_class_resp
+
+        pipeline.rag_pipeline.run.side_effect = Exception("BQ 429 rateLimitExceeded")
+
+        request = OrchestratorRunRequest(gcs_uri="gs://landing/file.pdf")
+        with pytest.raises(Exception, match="BQ 429 rateLimitExceeded"):
+            pipeline.run(request)
+
+        pipeline.classification_pipeline.cleanup_landing_zone.assert_not_called()

--- a/pipelines/enterprise_knowledge_base/tests/test_rag_ingestion.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_rag_ingestion.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +8,7 @@ from pipelines.enterprise_knowledge_base.app.rag_ingestion import (
     IngestDocumentRequest,
     RAGIngestion,
 )
+from pipelines.enterprise_knowledge_base.app.rag_ingestion.schemas import DocumentChunk
 
 
 @pytest.fixture(autouse=True)
@@ -137,3 +139,55 @@ def test_generate_embeddings_failure(mock_bq):
 
     assert response.success is False
     assert "BQ Error" in response.execution_status
+
+
+@pytest.fixture
+def sample_chunks():
+    return [
+        DocumentChunk(
+            chunk_id="1",
+            document_id="doc1",
+            chunk_data="sample text",
+            gcs_uri="gs://kb-it/proj/doc.pdf",
+            filename="doc.pdf",
+            page_number=1,
+            structural_metadata={"page": 1},
+            created_at=datetime.now(timezone.utc).isoformat(),
+        )
+    ]
+
+
+def test_stage_chunks_bq_retries_on_rate_limit(mock_bq, sample_chunks):
+    """Regression: _stage_chunks_bq must retry on 429 rateLimitExceeded and succeed
+    on the next attempt, not propagate the error immediately."""
+    service = RAGIngestion()
+
+    mock_job = MagicMock()
+    mock_job.result.side_effect = [
+        Exception("429 rateLimitExceeded: too many table update operations"),
+        None,
+    ]
+    mock_bq.load_table_from_json.return_value = mock_job
+
+    with patch(
+        "pipelines.enterprise_knowledge_base.app.rag_ingestion.pipeline.time.sleep"
+    ):
+        service._stage_chunks_bq(sample_chunks)
+
+    assert mock_bq.load_table_from_json.call_count == 2
+
+
+def test_stage_chunks_bq_raises_immediately_on_non_rate_limit_error(
+    mock_bq, sample_chunks
+):
+    """Verifies _stage_chunks_bq does not retry on non-rate-limit errors."""
+    service = RAGIngestion()
+
+    mock_job = MagicMock()
+    mock_job.result.side_effect = Exception("Permission denied")
+    mock_bq.load_table_from_json.return_value = mock_job
+
+    with pytest.raises(RuntimeError, match="Permission denied"):
+        service._stage_chunks_bq(sample_chunks)
+
+    assert mock_bq.load_table_from_json.call_count == 1

--- a/terraform/ekb_pipeline_resources/main.tf
+++ b/terraform/ekb_pipeline_resources/main.tf
@@ -98,12 +98,12 @@ resource "google_cloud_tasks_queue" "ekb_ingestion_queue" {
   location = var.main_region
 
   rate_limits {
-    max_concurrent_dispatches = 10
-    max_dispatches_per_second = 5
+    max_concurrent_dispatches = 5
+    max_dispatches_per_second = 2
   }
 
   retry_config {
-    max_attempts = 5
+    max_attempts = 1
     min_backoff  = "10s"
     max_backoff  = "300s"
   }


### PR DESCRIPTION
# EKB Pipeline — Bug Report & Fix Summary

  
  Two related bugs caused documents to fail ingestion repeatedly, each retry making recovery impossible.

  ---
  ## Bug 1 — Landing Zone Cleanup Race Condition

 ### Root cause

 The original document was deleted from the landing zone inside file_routing(), as the last step of the classification pipeline. Two operations still ran after that deletion:

  1. ingest_metadata_bq() — step 5 of ClassificationPipeline.run()
  2. rag_pipeline.run() — step 2 of KBIngestionPipeline.run()

If either failed, Cloud Tasks received a 500 and retried the task. On retry, the classification pipeline tried to copy the original from the landing zone and hit a 404 — No such object,
 making every subsequent retry an instant dead-end regardless of the actual failure.

###  Fixes implemented

1. Removed delete_blob calls from file_routing() — the method now only copies files to the domain bucket, never deletes from the landing zone. (pipeline.py)
2. Added cleanup_landing_zone() method to ClassificationPipeline — dedicated method that deletes the original and masked files from the landing zone. Each deletion is individually non-fatal (wrapped in try/except with a warning log) so a GCS hiccup at cleanup time does not fail an otherwise successful job. (pipeline.py)
3. Moved cleanup to the orchestrator as the final step — cleanup_landing_zone() is called only after both classification_pipeline.run() and rag_pipeline.run() succeed. Any failure before that point leaves the original intact in the landing zone, making every retry a clean re-run. (orchestrator.py)
4. Propagated sanitized_landing_uri through RunResponse — the classification pipeline returns the landing zone URI of the masked file (if masking occurred) so the orchestrator knows what to clean up without reaching into internal state. (schemas.py, pipeline.py)

  Resulting pipeline flow

  Landing zone (original + masked)
    │
    ├── ClassificationPipeline.run()
    │     ├── DLP scan          → landing zone URI
    │     ├── Masking           → landing zone URI
    │     ├── Gemini classify   → landing zone URI (masked)
    │     ├── file_routing()    → COPY to domain bucket  ← no deletion
    │     └── ingest_metadata_bq()
    │
    ├── rag_pipeline.run()      → domain bucket URI
    │
    └── cleanup_landing_zone()  → DELETE from landing zone  ← only here

  ---
##  Bug 2 — BigQuery table.write Rate Limit (429)

### Root cause

_stage_chunks_bq() had no retry logic — any BigQuery error immediately raised a RuntimeError and killed the pipeline. Under concurrent load, multiple tasks write to the same documents_chunks table simultaneously. Each task performs three sequential write operations on that table:

| Step | Operation|
| ---| --- |
| _clear_existing_chunks() | DELETE query |
| _stage_chunks_bq() | LOAD job |
|    _execute_embedding_query() | UPDATE query|

  With the original Cloud Tasks configuration of max_concurrent_dispatches = 10, up to 30 simultaneous write operations could hit documents_chunks, triggering BigQuery's table.write rate limit (429 rateLimitExceeded).

### Fixes implemented

1. Retry with exponential backoff + jitter in _stage_chunks_bq() — retries up to 3 times on 429/rateLimitExceeded errors only. Non-rate-limit errors are raised immediately. Backoff uses 5 * 2^attempt seconds plus random jitter (0–3s) to prevent synchronized retry storms when multiple concurrent tasks hit the limit at the same time. (rag_ingestion/pipeline.py)


  | Attempt | Base wait | With jitter |
  |---------|-----------|-------------|
  | 1       | 5s        | 5–8s        |
  | 2       | 10s       | 10–13s      |
  | 3       | raises    | —           |

2. Reduced Cloud Tasks queue concurrency — lowered max_concurrent_dispatches from 10 → 5 and max_dispatches_per_second from 5 → 2, reducing peak concurrent BQ writes from ~30 to ~15 and staggering task start times to further spread the write load. (terraform/ekb_pipeline_resources/main.tf)

