### PR TITLE
EKB Pipeline / Replace IAM Binding Conditions with Google Groups

### DIFF
--- a/pipelines/enterprise_knowledge_base/app/document_classification/gcs_service/service.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/gcs_service/service.py
@@ -164,65 +164,6 @@ class GCSService:
         blob = bucket.blob(uri_parts["blob_name"])
         self._execute_with_exponential_backoff(blob.delete)
 
-    def grant_iam_conditional_binding(
-        self, bucket_name: str, folder_prefix: str, uploader_email: str
-    ) -> None:
-        """Grants roles/storage.objectAdmin to the uploader on their folder in the domain bucket.
-
-        Uses a folder-level IAM condition (startsWith) so the single binding covers all current
-        and future files the uploader stores in that project/tier path. Skips silently if the
-        exact binding already exists.
-
-        Args:
-            bucket_name (str): Domain bucket name (e.g. "kb-it").
-            folder_prefix (str): Object path prefix for the user folder
-                (e.g. "project alpha/client-confidential/eamadorm11/").
-            uploader_email (str): Email address to receive the binding.
-
-        Returns:
-            None
-        """
-        logger.info(
-            f"Granting roles/storage.objectAdmin to {uploader_email} "
-            f"on gs://{bucket_name}/{folder_prefix}"
-        )
-        resource_prefix = f"projects/_/buckets/{bucket_name}/objects/{folder_prefix}"
-        condition_expr = f'resource.name.startsWith("{resource_prefix}")'
-
-        bucket = self.client.bucket(bucket_name)
-        iam_policy = self._execute_with_exponential_backoff(
-            bucket.get_iam_policy, requested_policy_version=3
-        )
-        iam_policy.version = 3
-
-        already_granted = any(
-            binding.get("role") == "roles/storage.objectAdmin"
-            and f"user:{uploader_email}" in binding.get("members", set())
-            and (binding.get("condition") or {}).get("expression") == condition_expr
-            for binding in iam_policy.bindings
-        )
-
-        if already_granted:
-            logger.debug(
-                f"IAM binding already exists for '{uploader_email}' on '{resource_prefix}'"
-            )
-            return
-
-        iam_policy.bindings.append(
-            {
-                "role": "roles/storage.objectAdmin",
-                "members": {f"user:{uploader_email}"},
-                "condition": {
-                    "title": "uploader-folder-access",
-                    "expression": condition_expr,
-                },
-            }
-        )
-        self._execute_with_exponential_backoff(bucket.set_iam_policy, iam_policy)
-        logger.info(
-            f"Granted roles/storage.objectAdmin to '{uploader_email}' on '{resource_prefix}'"
-        )
-
     def _parse_uri(self, gcs_uri: str) -> dict[str, str]:
         """Helper to split gs://bucket/path into dictionary components.
         Ensures the URI follows the expected gs:// protocol format.

--- a/pipelines/enterprise_knowledge_base/app/document_classification/pipeline.py
+++ b/pipelines/enterprise_knowledge_base/app/document_classification/pipeline.py
@@ -293,21 +293,14 @@ class ClassificationPipeline:
             request.final_security_tier, "unknown"
         )
         filename = request.original_landing_uri.split("/")[-1]
-        uploader_prefix = request.uploader_email.split("@")[0]
 
-        dest_base = f"gs://kb-{request.final_domain}/{request.project_name}/{tier_label}/{uploader_prefix}/"
+        dest_base = (
+            f"gs://kb-{request.final_domain}/{request.project_name}/{tier_label}/"
+        )
         final_original_uri = f"{dest_base}{filename}"
 
         # 1. Copy Original
         self.gcs.copy_blob(request.original_landing_uri, final_original_uri)
-
-        # Grant uploader Storage Object Admin on their entire folder in the domain bucket.
-        # One folder-level IAM condition covers both the original and any sanitized copy,
-        # since both land under the same dest_base prefix.
-        folder_prefix = f"{request.project_name}/{tier_label}/{uploader_prefix}/"
-        self.gcs.grant_iam_conditional_binding(
-            f"kb-{request.final_domain}", folder_prefix, request.uploader_email
-        )
 
         # 2. Copy Masked (if exists)
         final_sanitized_uri = None

--- a/pipelines/enterprise_knowledge_base/tests/test_document_classification.py
+++ b/pipelines/enterprise_knowledge_base/tests/test_document_classification.py
@@ -269,7 +269,7 @@ def test_run_orchestrates_full_pipeline_successfully(
     assert result.final_domain == "it"
     assert result.final_security_tier == 1
     # Should return original destination URI because no masking occurred
-    assert result.final_sanitized_uri == "gs://kb-it/p1/public/u1/doc.pdf"
+    assert result.final_sanitized_uri == "gs://kb-it/p1/public/doc.pdf"
 
     # Verify sequence
     mock_gcs.get_blob_metadata.assert_called()
@@ -277,50 +277,6 @@ def test_run_orchestrates_full_pipeline_successfully(
     mock_gemini.classify_document.assert_called()
     mock_gcs.copy_blob.assert_called()
     mock_bq.insert_metadata.assert_called()
-
-
-def test_file_routing_grants_iam_binding_on_uploader_folder(pipeline, mock_gcs):
-    """Verifies grant_iam_conditional_binding is called with the correct folder prefix."""
-    from pipelines.enterprise_knowledge_base.app.document_classification.schemas import (
-        FileRoutingRequest,
-    )
-
-    request = FileRoutingRequest(
-        original_landing_uri="gs://landing/proj/doc.pdf",
-        sanitized_landing_uri=None,
-        final_domain="it",
-        final_security_tier=1,
-        project_name="proj",
-        uploader_email="user@example.com",
-    )
-
-    pipeline.file_routing(request)
-
-    mock_gcs.grant_iam_conditional_binding.assert_called_once_with(
-        "kb-it", "proj/public/user/", "user@example.com"
-    )
-
-
-def test_file_routing_grants_iam_binding_once_even_with_sanitized(pipeline, mock_gcs):
-    """Verifies only one IAM binding call is made even when a sanitized copy also exists."""
-    from pipelines.enterprise_knowledge_base.app.document_classification.schemas import (
-        FileRoutingRequest,
-    )
-
-    request = FileRoutingRequest(
-        original_landing_uri="gs://landing/proj/secret.pdf",
-        sanitized_landing_uri="gs://landing/proj/secret_masked.pdf",
-        final_domain="hr",
-        final_security_tier=5,
-        project_name="proj",
-        uploader_email="admin@hr.com",
-    )
-
-    pipeline.file_routing(request)
-
-    mock_gcs.grant_iam_conditional_binding.assert_called_once_with(
-        "kb-hr", "proj/strictly-confidential/admin/", "admin@hr.com"
-    )
 
 
 def test_run_performs_cleanup_on_failure(pipeline, mock_gcs, mock_dlp, mock_gemini):
@@ -406,7 +362,7 @@ def test_run_returns_masked_uri_when_sanitized(
     # Should return the final destination of the MASKED file
     assert (
         result.final_sanitized_uri
-        == "gs://kb-executives/top-secret/strictly-confidential/admin/secret_masked.txt"
+        == "gs://kb-executives/top-secret/strictly-confidential/secret_masked.txt"
     )
 
 


### PR DESCRIPTION
## The problem:

The old folder path structure of the files inside the EKB (in GCS) was:
   - bucket / project / security-tier / uploader-email / filename

This caused that, if a file was uploaded by User 1, but User 2 generated a updated version, and wanted to upload it into the EKB, the files were saved in different folders, without replacing the old version:

 - bucket / project / security-tier / uploader-email-1 / custom-filename.pdf
 - bucket / project / security-tier / uploader-email-2 / custom-filename.pdf

So now, folder paths are built in the following way:
- **bucket / project / security-tier / custom-filename.pdf**

Allowing anyone with the permission to write to this bucket (Using Google Groups and versioning in GCS) to upload a file they originally didn't upload. The tracking of who uploaded the file still remains inside the blob metadata (which is also versioned)