### PR TITLE
Deployments / Set CloudRun min instance parameter to zero

### DIFF
--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
@@ -111,7 +111,7 @@ steps:
           --entrypoint-object=app \
           --requirements-file=./agent/core_agent/requirements.txt \
           --service-account=${_AGENT_SA}@${PROJECT_ID}.iam.gserviceaccount.com \
-          --min-instances=1 \
+          --min-instances=0 \
           --num-workers=4 \
           --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GCS_URL=${_GCS_URL},CALENDAR_URL=${_CALENDAR_URL},GEMINI_GOOGLE_AUTH_ID=$$GEMINI_GOOGLE_AUTH_ID,EKB_PIPELINE_URL=${_EKB_PIPELINE_URL}" 2>&1 | tee deploy_output.txt
         

--- a/terraform/bq_mcp_server_resources/main.tf
+++ b/terraform/bq_mcp_server_resources/main.tf
@@ -46,6 +46,11 @@ module "mcp_server_cloud_run" {
   project_id = var.project_id
   region     = local.cloud_run_region
   name       = var.mcp_server_cloud_run_name
+  labels     = var.mcp_server_cloud_run_labels
+
+  revision = {
+    labels = var.mcp_server_cloud_run_labels
+  }
 
   containers = {
     mcp-server = {

--- a/terraform/bq_mcp_server_resources/terraform.tfvars
+++ b/terraform/bq_mcp_server_resources/terraform.tfvars
@@ -39,6 +39,6 @@ mcp_server_cloud_run_env = {
   "LOG_LEVEL" = "INFO"
 }
 
-mcp_server_cloud_run_min_instances = 1
+mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"

--- a/terraform/bq_mcp_server_resources/terraform.tfvars
+++ b/terraform/bq_mcp_server_resources/terraform.tfvars
@@ -42,3 +42,7 @@ mcp_server_cloud_run_env = {
 mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"
+mcp_server_cloud_run_labels = {
+  "service"   = "bq-mcp-server"
+  "component" = "mcp-server"
+}

--- a/terraform/bq_mcp_server_resources/variables.tf
+++ b/terraform/bq_mcp_server_resources/variables.tf
@@ -81,3 +81,9 @@ variable "mcp_server_cloud_run_memory" {
   type        = string
   default     = "512Mi"
 }
+
+variable "mcp_server_cloud_run_labels" {
+  description = "A map of labels to apply to the Cloud Run service and revision."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/drive_mcp_server_resources/main.tf
+++ b/terraform/drive_mcp_server_resources/main.tf
@@ -38,6 +38,11 @@ module "mcp_server_cloud_run" {
   project_id = var.project_id
   region     = local.cloud_run_region
   name       = var.mcp_server_cloud_run_name
+  labels     = var.mcp_server_cloud_run_labels
+
+  revision = {
+    labels = var.mcp_server_cloud_run_labels
+  }
 
   containers = {
     mcp-server = {

--- a/terraform/drive_mcp_server_resources/terraform.tfvars
+++ b/terraform/drive_mcp_server_resources/terraform.tfvars
@@ -38,3 +38,7 @@ mcp_server_cloud_run_env = {
 mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"
+mcp_server_cloud_run_labels = {
+  "service"   = "drive-mcp-server"
+  "component" = "mcp-server"
+}

--- a/terraform/drive_mcp_server_resources/terraform.tfvars
+++ b/terraform/drive_mcp_server_resources/terraform.tfvars
@@ -35,6 +35,6 @@ mcp_server_cloud_run_env = {
   "LOG_LEVEL" = "INFO"
 }
 
-mcp_server_cloud_run_min_instances = 1
+mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"

--- a/terraform/drive_mcp_server_resources/variables.tf
+++ b/terraform/drive_mcp_server_resources/variables.tf
@@ -81,3 +81,9 @@ variable "mcp_server_cloud_run_memory" {
   type        = string
   default     = "512Mi"
 }
+
+variable "mcp_server_cloud_run_labels" {
+  description = "A map of labels to apply to the Cloud Run service and revision."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcs_mcp_server_resources/main.tf
+++ b/terraform/gcs_mcp_server_resources/main.tf
@@ -38,6 +38,11 @@ module "mcp_server_cloud_run" {
   project_id = var.project_id
   region     = local.cloud_run_region
   name       = var.mcp_server_cloud_run_name
+  labels     = var.mcp_server_cloud_run_labels
+
+  revision = {
+    labels = var.mcp_server_cloud_run_labels
+  }
 
   containers = {
     mcp-server = {

--- a/terraform/gcs_mcp_server_resources/terraform.tfvars
+++ b/terraform/gcs_mcp_server_resources/terraform.tfvars
@@ -41,6 +41,10 @@ mcp_server_cloud_run_env = {
 mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"
+mcp_server_cloud_run_labels = {
+  "service"   = "gcs-mcp-server"
+  "component" = "mcp-server"
+}
 
 landing_zone_bucket = "ai_agent_landing_zone"
 kb_ingestion_bucket = "ag-core-dev-fdx7-kb-landing-zone"

--- a/terraform/gcs_mcp_server_resources/terraform.tfvars
+++ b/terraform/gcs_mcp_server_resources/terraform.tfvars
@@ -38,7 +38,7 @@ mcp_server_cloud_run_env = {
   "GCS_KB_INGESTION_BUCKET" = "ag-core-dev-fdx7-kb-landing-zone"
 }
 
-mcp_server_cloud_run_min_instances = 1
+mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"
 

--- a/terraform/gcs_mcp_server_resources/variables.tf
+++ b/terraform/gcs_mcp_server_resources/variables.tf
@@ -82,6 +82,12 @@ variable "mcp_server_cloud_run_memory" {
   default     = "512Mi"
 }
 
+variable "mcp_server_cloud_run_labels" {
+  description = "A map of labels to apply to the Cloud Run service and revision."
+  type        = map(string)
+  default     = {}
+}
+
 variable "landing_zone_bucket" {
   description = "The name of the GCS bucket used as the landing zone for user uploads."
   type        = string

--- a/terraform/google_calendar_mcp_server_resources/main.tf
+++ b/terraform/google_calendar_mcp_server_resources/main.tf
@@ -36,6 +36,11 @@ module "mcp_server_cloud_run" {
   project_id = var.project_id
   region     = local.cloud_run_region
   name       = var.mcp_server_cloud_run_name
+  labels     = var.mcp_server_cloud_run_labels
+
+  revision = {
+    labels = var.mcp_server_cloud_run_labels
+  }
 
   containers = {
     mcp-server = {

--- a/terraform/google_calendar_mcp_server_resources/terraform.tfvars
+++ b/terraform/google_calendar_mcp_server_resources/terraform.tfvars
@@ -33,6 +33,6 @@ mcp_server_cloud_run_env = {
   "LOG_LEVEL" = "INFO"
 }
 
-mcp_server_cloud_run_min_instances = 1
+mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"

--- a/terraform/google_calendar_mcp_server_resources/terraform.tfvars
+++ b/terraform/google_calendar_mcp_server_resources/terraform.tfvars
@@ -36,3 +36,7 @@ mcp_server_cloud_run_env = {
 mcp_server_cloud_run_min_instances = 0
 mcp_server_cloud_run_cpu           = "1"
 mcp_server_cloud_run_memory        = "512Mi"
+mcp_server_cloud_run_labels = {
+  "service"   = "calendar-mcp-server"
+  "component" = "mcp-server"
+}

--- a/terraform/google_calendar_mcp_server_resources/variables.tf
+++ b/terraform/google_calendar_mcp_server_resources/variables.tf
@@ -77,3 +77,9 @@ variable "mcp_server_cloud_run_memory" {
   type        = string
   default     = "512Mi"
 }
+
+variable "mcp_server_cloud_run_labels" {
+  description = "A map of labels to apply to the Cloud Run service and revision."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This is done to reduce idle costs and to audit costs per CloudRun instance