### PR TITLE
Infrastructure / Centralize and Standardize Data Foundation Naming Convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_ID?=ag-core-dev-fdx7 # ?= is used to set a default value if the variable is not set in the .env file
+PROJECT_ID?=ag-core-ops-auj0# ?= is used to set a default value if the variable is not set in the .env file
 REGION?=us-central1
 BIGQUERY_PROD_URL?=https://bigquery-mcp-server-753988132239.us-central1.run.app
 DRIVE_PROD_URL?=https://drive-mcp-server-753988132239.us-central1.run.app
@@ -13,6 +13,10 @@ gcloud-auth:
 	gcloud config unset auth/impersonate_service_account
 	gcloud auth application-default login --project=$(PROJECT_ID)
 	gcloud config set project $(PROJECT_ID)
+
+gcloud-auth-terraform:
+	gcloud auth application-default login --project=$(PROJECT_ID) --impersonate-service-account=terraform-sa-gemini-project@$(PROJECT_ID).iam.gserviceaccount.com
+	gcloud config set auth/impersonate_service_account terraform-sa-gemini-project@$(PROJECT_ID).iam.gserviceaccount.com
 
 install-precommit:
 	uvx pre-commit install

--- a/terraform/ai_agent_resources/main.tf
+++ b/terraform/ai_agent_resources/main.tf
@@ -60,26 +60,8 @@ resource "google_project_iam_member" "discovery_engine_service_agent_roles" {
   ]
 }
 
-################ Storage ################
-
-resource "google_storage_bucket" "artifact_bucket" {
-  project                     = var.project_id
-  name                        = var.artifact_bucket_name
-  location                    = var.main_region
-  uniform_bucket_level_access = true
-  force_destroy               = true
-
-  versioning {
-    enabled = true
-  }
-
-  depends_on = [
-    module.enable_apis
-  ]
-}
-
 resource "google_storage_bucket_iam_member" "ai_agent_artifact_bucket_admin" {
-  bucket = google_storage_bucket.artifact_bucket.name
+  bucket = "${var.project_id}-${var.artifact_bucket_name}"
   role   = "roles/storage.admin"
   member = "serviceAccount:${module.ai-agent-service-account.email}"
 }

--- a/terraform/ai_agent_resources/terraform.tfvars
+++ b/terraform/ai_agent_resources/terraform.tfvars
@@ -10,7 +10,7 @@ apis_to_enable = {
   ]
 }
 ai_agent_service_account_name = "adk-agent"
-artifact_bucket_name          = "ai_agent_landing_zone"
+artifact_bucket_name          = "ai-agent-landing-zone"
 
 ai_agent_iam_project_roles = {
   "ag-core-dev-fdx7" = [

--- a/terraform/ekb_pipeline_resources/main.tf
+++ b/terraform/ekb_pipeline_resources/main.tf
@@ -45,11 +45,11 @@ module "ekb_pipeline_cloud_run" {
       env = merge(var.ekb_pipeline_cloud_run_env, {
         PROJECT_ID            = var.project_id
         GEMINI_LOCATION       = var.main_region
-        BQ_DATASET            = google_bigquery_dataset.knowledge_base.dataset_id
-        BQ_CHUNKS_TABLE       = google_bigquery_table.documents_chunks.table_id
-        BQ_METADATA_TABLE     = google_bigquery_table.documents_metadata.table_id
-        BQ_JOBS_TABLE         = google_bigquery_table.ingestion_jobs.table_id
-        RAG_STAGING_BUCKET    = google_storage_bucket.rag_staging.name
+        BQ_DATASET            = var.bq_dataset_id
+        BQ_CHUNKS_TABLE       = var.bq_chunks_table_id
+        BQ_METADATA_TABLE     = var.bq_metadata_table_id
+        BQ_JOBS_TABLE         = var.bq_jobs_table_id
+        RAG_STAGING_BUCKET    = "${var.project_id}${var.rag_staging_bucket_suffix}"
         TASKS_QUEUE_ID        = google_cloud_tasks_queue.ekb_ingestion_queue.name
         TASKS_LOCATION        = var.main_region
         SERVICE_ACCOUNT_EMAIL = module.ekb-pipeline-service-account.email
@@ -123,298 +123,6 @@ resource "google_project_iam_member" "cloudtasks_oidc_creator" {
   member  = "serviceAccount:${module.ekb-pipeline-service-account.email}"
 }
 
-################ BigQuery ML Model ################
-
-resource "google_bigquery_connection" "vertex_ai_connection" {
-  connection_id = "vertex_ai_connection"
-  project       = var.project_id
-  location      = var.main_region
-  friendly_name = "Connection for Vertex AI embeddings"
-  cloud_resource {}
-}
-
-resource "google_project_iam_member" "connection_ai_user" {
-  project = var.project_id
-  role    = "roles/aiplatform.user"
-  member  = "serviceAccount:${google_bigquery_connection.vertex_ai_connection.cloud_resource[0].service_account_id}"
-}
-
-resource "google_bigquery_job" "create_multimodal_model" {
-  job_id   = "create_model_${formatdate("YYYYMMDDhhmmss", timestamp())}"
-  project  = var.project_id
-  location = var.main_region
-
-  query {
-    query              = <<EOF
-      CREATE OR REPLACE MODEL `knowledge_base.multimodal_embedding_model`
-      REMOTE WITH CONNECTION `${var.project_id}.${var.main_region}.${google_bigquery_connection.vertex_ai_connection.connection_id}`
-      OPTIONS (ENDPOINT = 'multimodalembedding@001');
-EOF
-    use_legacy_sql     = false
-    create_disposition = ""
-    write_disposition  = ""
-  }
-
-  lifecycle {
-    ignore_changes = [job_id]
-  }
-
-  depends_on = [
-    google_bigquery_connection.vertex_ai_connection,
-    google_project_iam_member.connection_ai_user,
-    google_bigquery_table.documents_chunks,
-    module.enable_apis
-  ]
-}
-
-################ EKB Infrastructure (Migrated) ################
-
-resource "google_bigquery_dataset" "knowledge_base" {
-  project                    = var.project_id
-  dataset_id                 = "knowledge_base"
-  friendly_name              = "knowledge_base"
-  description                = "Enterprise Knowledge Base dataset"
-  location                   = var.main_region
-  delete_contents_on_destroy = true
-
-  depends_on = [module.enable_apis]
-}
-
-resource "google_bigquery_table" "documents_chunks" {
-  project             = var.project_id
-  dataset_id          = google_bigquery_dataset.knowledge_base.dataset_id
-  table_id            = "documents_chunks"
-  deletion_protection = false
-
-  schema = <<EOF
-[
-  {
-    "name": "chunk_id",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Unique UUID for the chunk"
-  },
-  {
-    "name": "document_id",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Deterministic UUID for the document"
-  },
-  {
-    "name": "chunk_data",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Text content of the chunk"
-  },
-  {
-    "name": "gcs_uri",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Original GCS URI of the document"
-  },
-  {
-    "name": "filename",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Basename of the file"
-  },
-  {
-    "name": "structural_metadata",
-    "type": "JSON",
-    "mode": "REQUIRED",
-    "description": "Structured page info, layout data, etc."
-  },
-  {
-    "name": "page_number",
-    "type": "INTEGER",
-    "mode": "REQUIRED",
-    "description": "Page number where the chunk was found"
-  },
-  {
-    "name": "embedding",
-    "type": "FLOAT64",
-    "mode": "REPEATED",
-    "description": "Vector embedding (empty initially)"
-  },
-  {
-    "name": "created_at",
-    "type": "TIMESTAMP",
-    "mode": "REQUIRED",
-    "description": "ISO timestamp of creation"
-  },
-  {
-    "name": "vectorized_at",
-    "type": "TIMESTAMP",
-    "mode": "NULLABLE",
-    "description": "ISO timestamp of vectorization"
-  }
-]
-EOF
-}
-
-resource "google_bigquery_table" "documents_metadata" {
-  project             = var.project_id
-  dataset_id          = google_bigquery_dataset.knowledge_base.dataset_id
-  table_id            = "documents_metadata"
-  deletion_protection = false
-
-  schema = <<EOF
-[
-  {
-    "name": "document_id",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Unique UUID for the document"
-  },
-  {
-    "name": "gcs_uri",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Final GCS URI in the domain bucket (Original)"
-  },
-  {
-    "name": "filename",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "The original filename"
-  },
-  {
-    "name": "classification_tier",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "String classification label (public, confidential, etc.)"
-  },
-  {
-    "name": "domain",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "The business domain (it, hr, etc.)"
-  },
-  {
-    "name": "confidence_score",
-    "type": "FLOAT64",
-    "mode": "REQUIRED",
-    "description": "AI classifier confidence (0.0 - 1.0)"
-  },
-  {
-    "name": "trust_level",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Trust maturity (published, wip, archived)"
-  },
-  {
-    "name": "project_id",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Project identifier"
-  },
-  {
-    "name": "uploader_email",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Uploader's email address"
-  },
-  {
-    "name": "description",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "AI-generated content summary"
-  },
-  {
-    "name": "version",
-    "type": "INTEGER",
-    "mode": "REQUIRED",
-    "description": "Incremental version number"
-  },
-  {
-    "name": "latest",
-    "type": "BOOLEAN",
-    "mode": "REQUIRED",
-    "description": "Whether this is the latest version"
-  },
-  {
-    "name": "ingested_at",
-    "type": "TIMESTAMP",
-    "mode": "REQUIRED",
-    "description": "ISO 8601 ingestion timestamp"
-  }
-]
-EOF
-}
-
-resource "google_bigquery_table" "ingestion_jobs" {
-  project             = var.project_id
-  dataset_id          = google_bigquery_dataset.knowledge_base.dataset_id
-  table_id            = "ingestion_jobs"
-  deletion_protection = false
-
-  schema = <<EOF
-[
-  {
-    "name": "job_id",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Unique UUID for the ingestion job"
-  },
-  {
-    "name": "filename",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Basename of the file being ingested"
-  },
-  {
-    "name": "status",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Current status (processing, success, error)"
-  },
-  {
-    "name": "message",
-    "type": "STRING",
-    "mode": "REQUIRED",
-    "description": "Informational or error message"
-  },
-  {
-    "name": "start_time",
-    "type": "TIMESTAMP",
-    "mode": "REQUIRED",
-    "description": "When the job was initiated"
-  },
-  {
-    "name": "end_time",
-    "type": "TIMESTAMP",
-    "mode": "NULLABLE",
-    "description": "When the job was finalized"
-  },
-  {
-    "name": "metadata",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "Stringified JSON containing final processing results"
-  }
-]
-EOF
-}
-
-resource "google_storage_bucket" "kb_landing_zone" {
-  project       = var.project_id
-  name          = "${var.project_id}-kb-landing-zone"
-  location      = var.main_region
-  force_destroy = true
-
-  uniform_bucket_level_access = true
-  depends_on                  = [module.enable_apis]
-}
-
-resource "google_storage_bucket" "rag_staging" {
-  project       = var.project_id
-  name          = "${var.project_id}-rag-staging"
-  location      = var.main_region
-  force_destroy = true
-
-  uniform_bucket_level_access = true
-  depends_on                  = [module.enable_apis]
-}
 
 locals {
   kb_domains = [
@@ -428,24 +136,14 @@ locals {
   ]
 }
 
-resource "google_storage_bucket" "kb_domain_buckets" {
-  for_each = toset(local.kb_domains)
 
-  project       = var.project_id
-  name          = "kb-${each.value}"
-  location      = var.main_region
-  force_destroy = true
-
-  uniform_bucket_level_access = true
-  depends_on                  = [module.enable_apis]
-}
 
 ################ IAM (Resource Level) ################
 
 # BQ Dataset Access
 resource "google_bigquery_dataset_iam_member" "ekb_sa_bq_editor" {
   project    = var.project_id
-  dataset_id = google_bigquery_dataset.knowledge_base.dataset_id
+  dataset_id = var.bq_dataset_id
   role       = "roles/bigquery.dataEditor"
   member     = "serviceAccount:${module.ekb-pipeline-service-account.email}"
 }
@@ -454,21 +152,21 @@ resource "google_bigquery_dataset_iam_member" "ekb_sa_bq_editor" {
 resource "google_bigquery_connection_iam_member" "ekb_sa_connection_user" {
   project       = var.project_id
   location      = var.main_region
-  connection_id = google_bigquery_connection.vertex_ai_connection.connection_id
+  connection_id = var.bq_vertex_connection_id
   role          = "roles/bigquery.connectionUser"
   member        = "serviceAccount:${module.ekb-pipeline-service-account.email}"
 }
 
 # GCS Bucket Access (Landing Zone)
 resource "google_storage_bucket_iam_member" "ekb_sa_landing_admin" {
-  bucket = google_storage_bucket.kb_landing_zone.name
+  bucket = "${var.project_id}${var.kb_landing_zone_bucket_suffix}"
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${module.ekb-pipeline-service-account.email}"
 }
 
 # GCS Bucket Access (RAG Staging)
 resource "google_storage_bucket_iam_member" "ekb_sa_rag_admin" {
-  bucket = google_storage_bucket.rag_staging.name
+  bucket = "${var.project_id}${var.rag_staging_bucket_suffix}"
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${module.ekb-pipeline-service-account.email}"
 }
@@ -478,8 +176,8 @@ resource "google_storage_bucket_iam_member" "ekb_sa_rag_admin" {
 # getIamPolicy/setIamPolicy on each domain bucket to grant uploaders conditional access
 # to their own folder after routing.
 resource "google_storage_bucket_iam_member" "ekb_sa_domain_admin" {
-  for_each = google_storage_bucket.kb_domain_buckets
-  bucket   = each.value.name
+  for_each = toset(local.kb_domains)
+  bucket   = "${var.project_id}-${var.kb_domain_bucket_prefix}${each.value}"
   role     = "roles/storage.admin"
   member   = "serviceAccount:${module.ekb-pipeline-service-account.email}"
 }

--- a/terraform/ekb_pipeline_resources/terraform.tfvars
+++ b/terraform/ekb_pipeline_resources/terraform.tfvars
@@ -45,3 +45,14 @@ ekb_pipeline_cloud_run_min_instances = 0
 ekb_pipeline_cloud_run_env = {
   "LOG_LEVEL" = "INFO"
 }
+
+################ Naming Configuration for Shared Resources ################
+
+bq_vertex_connection_id       = "vertex_ai_connection"
+bq_dataset_id                 = "knowledge_base"
+bq_chunks_table_id            = "documents_chunks"
+bq_metadata_table_id          = "documents_metadata"
+bq_jobs_table_id              = "ingestion_jobs"
+kb_landing_zone_bucket_suffix = "-kb-landing-zone"
+rag_staging_bucket_suffix     = "-rag-staging"
+kb_domain_bucket_prefix       = "kb-"

--- a/terraform/ekb_pipeline_resources/variables.tf
+++ b/terraform/ekb_pipeline_resources/variables.tf
@@ -88,3 +88,36 @@ variable "ekb_pipeline_cloud_run_min_instances" {
   type        = number
   default     = 0
 }
+
+variable "bq_vertex_connection_id" {
+  type = string
+}
+
+variable "bq_dataset_id" {
+  type = string
+}
+
+variable "bq_chunks_table_id" {
+  type = string
+}
+
+variable "bq_metadata_table_id" {
+  type = string
+}
+
+variable "bq_jobs_table_id" {
+  type = string
+}
+
+variable "kb_landing_zone_bucket_suffix" {
+  type = string
+}
+
+variable "rag_staging_bucket_suffix" {
+  type = string
+}
+
+variable "kb_domain_bucket_prefix" {
+  type = string
+}
+

--- a/terraform/gcs_mcp_server_resources/terraform.tfvars
+++ b/terraform/gcs_mcp_server_resources/terraform.tfvars
@@ -1,13 +1,13 @@
 ################ Project configuration ################
 
-project_id             = "ag-core-dev-fdx7"
+project_id             = "ag-core-ops-auj0"
 main_region            = "us-central1"
 developers_group_email = "gcu_latam_team_devs@endava.com"
 
 ################ APIs to enable ################
 
 apis_to_enable = {
-  "ag-core-dev-fdx7" = [
+  "ag-core-ops-auj0" = [
     "storage.googleapis.com",
     "run.googleapis.com",
     "artifactregistry.googleapis.com"
@@ -19,7 +19,7 @@ apis_to_enable = {
 mcp_server_service_account_name = "gcs-mcp-server"
 
 mcp_server_iam_project_roles = {
-  "ag-core-dev-fdx7" = []
+  "ag-core-ops-auj0" = []
 }
 
 ################ Artifact Registry ################
@@ -34,8 +34,8 @@ mcp_server_cloud_run_image_tag = "latest"
 
 mcp_server_cloud_run_env = {
   "LOG_LEVEL"               = "INFO"
-  "GCS_LANDING_ZONE_BUCKET" = "ai_agent_landing_zone"
-  "GCS_KB_INGESTION_BUCKET" = "ag-core-dev-fdx7-kb-landing-zone"
+  "GCS_LANDING_ZONE_BUCKET" = "ag-core-ops-auj0-ai-agent-landing-zone"
+  "GCS_KB_INGESTION_BUCKET" = "ag-core-ops-auj0-kb-landing-zone"
 }
 
 mcp_server_cloud_run_min_instances = 0
@@ -46,5 +46,5 @@ mcp_server_cloud_run_labels = {
   "component" = "mcp-server"
 }
 
-landing_zone_bucket = "ai_agent_landing_zone"
-kb_ingestion_bucket = "ag-core-dev-fdx7-kb-landing-zone"
+landing_zone_bucket = "ag-core-ops-auj0-ai-agent-landing-zone"
+kb_ingestion_bucket = "ag-core-ops-auj0-kb-landing-zone"

--- a/terraform/google_calendar_mcp_server_resources/terraform.tfvars
+++ b/terraform/google_calendar_mcp_server_resources/terraform.tfvars
@@ -1,12 +1,12 @@
 ################ Project configuration ################
 
-project_id  = "ag-core-dev-fdx7"
+project_id  = "ag-core-ops-auj0"
 main_region = "us-central1"
 
 ################ APIs to enable ################
 
 apis_to_enable = {
-  "ag-core-dev-fdx7" = [
+  "ag-core-ops-auj0" = [
     "calendar-json.googleapis.com",
     "meet.googleapis.com"
   ],

--- a/terraform/scripts/README.md
+++ b/terraform/scripts/README.md
@@ -23,6 +23,18 @@ Before running the script, ensure the following conditions are met:
 
 4. Developer group: the developer Google Group must already exist in your organization.
 
+5. Cloud Build Service Agent Permissions (Mandatory for GitHub Connection):
+    - When creating a 2nd Gen GitHub Connection, Cloud Build needs to store tokens in Secret Manager.
+    - You must grant the **Secret Manager Admin** role to the Cloud Build Service Agent (`service-PROJECT_NUMBER@gcp-sa-cloudbuild.iam.gserviceaccount.com`).
+    - **Command**:
+      ```bash
+      PROJECT_NUMBER=$(gcloud projects describe YOUR_PROJECT_ID --format='value(projectNumber)')
+      gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+          --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-cloudbuild.iam.gserviceaccount.com" \
+          --role="roles/secretmanager.admin"
+      ```
+    - Ensure the **Secret Manager API** is enabled before creating the connection.
+
 ## Architecture Flow
 The script performs the following steps:
 

--- a/terraform/scripts/bootstrap.sh
+++ b/terraform/scripts/bootstrap.sh
@@ -9,7 +9,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # --- Configuration ---
 
 #service accounts and IAM roles (exported for use in sub-scripts)
-export PROJECT_ID="ag-core-dev-fdx7"
+export PROJECT_ID="ag-core-ops-auj0"
 export SA_NAME="terraform-sa-gemini-project"
 export SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 USER_EMAIL="emmanuel.amador@endava.com"
@@ -24,7 +24,7 @@ REPO_NAME="Research-Agent"
 REPO_OWNER="eamadorm-endava"
 BRANCH_NAME="" # Your specific development branch
 export GITHUB_REGION="us-central1"
-export GITHUB_CONNECTION_NAME="eamadorm-github"
+export GITHUB_CONNECTION_NAME="eamadorm-github-connection"
 APPLY_SHARED_RESOURCES="${APPLY_SHARED_RESOURCES:-true}"
 
 echo "Starting bootstrap for project: $PROJECT_ID"

--- a/terraform/shared_resources/main.tf
+++ b/terraform/shared_resources/main.tf
@@ -26,6 +26,169 @@ module "artifact_registry" {
   }
 
   depends_on = [module.enable_apis]
+} ################ BigQuery Data Foundation ################
+
+resource "google_bigquery_connection" "vertex_ai_connection" {
+  connection_id = var.bq_vertex_connection_id
+  project       = var.project_id
+  location      = var.main_region
+  friendly_name = "Connection for Vertex AI embeddings"
+  cloud_resource {}
+  depends_on = [module.enable_apis]
+}
+
+resource "google_project_iam_member" "connection_ai_user" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_bigquery_connection.vertex_ai_connection.cloud_resource[0].service_account_id}"
+}
+
+resource "google_bigquery_dataset" "knowledge_base" {
+  project                    = var.project_id
+  dataset_id                 = var.bq_dataset_id
+  friendly_name              = "knowledge_base"
+  description                = "Enterprise Knowledge Base dataset"
+  location                   = var.main_region
+  delete_contents_on_destroy = true
+  depends_on                 = [module.enable_apis]
+}
+
+resource "google_bigquery_job" "create_multimodal_model" {
+  job_id   = "create_model_${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  project  = var.project_id
+  location = var.main_region
+
+  query {
+    query              = <<EOF
+      CREATE OR REPLACE MODEL `${var.bq_dataset_id}.multimodal_embedding_model`
+      REMOTE WITH CONNECTION `${var.project_id}.${var.main_region}.${google_bigquery_connection.vertex_ai_connection.connection_id}`
+      OPTIONS (ENDPOINT = 'multimodalembedding@001');
+EOF
+    use_legacy_sql     = false
+    create_disposition = ""
+    write_disposition  = ""
+  }
+
+  lifecycle {
+    ignore_changes = [job_id]
+  }
+
+  depends_on = [
+    google_bigquery_connection.vertex_ai_connection,
+    google_project_iam_member.connection_ai_user,
+    google_bigquery_dataset.knowledge_base
+  ]
+}
+
+resource "google_bigquery_table" "documents_chunks" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.knowledge_base.dataset_id
+  table_id            = var.bq_chunks_table_id
+  deletion_protection = false
+
+  schema = <<EOF
+[
+  { "name": "chunk_id", "type": "STRING", "mode": "REQUIRED", "description": "Unique UUID for the chunk" },
+  { "name": "document_id", "type": "STRING", "mode": "REQUIRED", "description": "Deterministic UUID for the document" },
+  { "name": "chunk_data", "type": "STRING", "mode": "REQUIRED", "description": "Text content of the chunk" },
+  { "name": "gcs_uri", "type": "STRING", "mode": "REQUIRED", "description": "Original GCS URI of the document" },
+  { "name": "filename", "type": "STRING", "mode": "REQUIRED", "description": "Basename of the file" },
+  { "name": "structural_metadata", "type": "JSON", "mode": "REQUIRED", "description": "Structured page info, layout data, etc." },
+  { "name": "page_number", "type": "INTEGER", "mode": "REQUIRED", "description": "Page number where the chunk was found" },
+  { "name": "embedding", "type": "FLOAT64", "mode": "REPEATED", "description": "Vector embedding (empty initially)" },
+  { "name": "created_at", "type": "TIMESTAMP", "mode": "REQUIRED", "description": "ISO timestamp of creation" },
+  { "name": "vectorized_at", "type": "TIMESTAMP", "mode": "NULLABLE", "description": "ISO timestamp of vectorization" }
+]
+EOF
+}
+
+resource "google_bigquery_table" "documents_metadata" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.knowledge_base.dataset_id
+  table_id            = var.bq_metadata_table_id
+  deletion_protection = false
+
+  schema = <<EOF
+[
+  { "name": "document_id", "type": "STRING", "mode": "REQUIRED", "description": "Unique UUID for the document" },
+  { "name": "gcs_uri", "type": "STRING", "mode": "REQUIRED", "description": "Final GCS URI in the domain bucket (Original)" },
+  { "name": "filename", "type": "STRING", "mode": "REQUIRED", "description": "The original filename" },
+  { "name": "classification_tier", "type": "STRING", "mode": "REQUIRED", "description": "String classification label (public, confidential, etc.)" },
+  { "name": "domain", "type": "STRING", "mode": "REQUIRED", "description": "The business domain (it, hr, etc.)" },
+  { "name": "confidence_score", "type": "FLOAT64", "mode": "REQUIRED", "description": "AI classifier confidence (0.0 - 1.0)" },
+  { "name": "trust_level", "type": "STRING", "mode": "REQUIRED", "description": "Trust maturity (published, wip, archived)" },
+  { "name": "project_id", "type": "STRING", "mode": "REQUIRED", "description": "Project identifier" },
+  { "name": "uploader_email", "type": "STRING", "mode": "REQUIRED", "description": "Uploader's email address" },
+  { "name": "description", "type": "STRING", "mode": "REQUIRED", "description": "AI-generated content summary" },
+  { "name": "version", "type": "INTEGER", "mode": "REQUIRED", "description": "Incremental version number" },
+  { "name": "latest", "type": "BOOLEAN", "mode": "REQUIRED", "description": "Whether this is the latest version" },
+  { "name": "ingested_at", "type": "TIMESTAMP", "mode": "REQUIRED", "description": "ISO 8601 ingestion timestamp" }
+]
+EOF
+}
+
+resource "google_bigquery_table" "ingestion_jobs" {
+  project             = var.project_id
+  dataset_id          = google_bigquery_dataset.knowledge_base.dataset_id
+  table_id            = var.bq_jobs_table_id
+  deletion_protection = false
+
+  schema = <<EOF
+[
+  { "name": "job_id", "type": "STRING", "mode": "REQUIRED", "description": "Unique UUID for the ingestion job" },
+  { "name": "filename", "type": "STRING", "mode": "REQUIRED", "description": "Basename of the file being ingested" },
+  { "name": "status", "type": "STRING", "mode": "REQUIRED", "description": "Current status (processing, success, error)" },
+  { "name": "message", "type": "STRING", "mode": "REQUIRED", "description": "Informational or error message" },
+  { "name": "start_time", "type": "TIMESTAMP", "mode": "REQUIRED", "description": "When the job was initiated" },
+  { "name": "end_time", "type": "TIMESTAMP", "mode": "NULLABLE", "description": "When the job was finalized" },
+  { "name": "metadata", "type": "STRING", "mode": "NULLABLE", "description": "Stringified JSON containing final processing results" }
+]
+EOF
+}
+
+################ Storage Data Foundation ################
+
+resource "google_storage_bucket" "kb_landing_zone" {
+  project                     = var.project_id
+  name                        = "${var.project_id}${var.kb_landing_zone_bucket_suffix}"
+  location                    = var.main_region
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  depends_on                  = [module.enable_apis]
+}
+
+resource "google_storage_bucket" "rag_staging" {
+  project                     = var.project_id
+  name                        = "${var.project_id}${var.rag_staging_bucket_suffix}"
+  location                    = var.main_region
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  depends_on                  = [module.enable_apis]
+}
+
+resource "google_storage_bucket" "kb_domain_buckets" {
+  for_each = toset(var.kb_domains)
+
+  project                     = var.project_id
+  name                        = "${var.project_id}-${var.kb_domain_bucket_prefix}${each.value}"
+  location                    = var.main_region
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  depends_on                  = [module.enable_apis]
+}
+
+resource "google_storage_bucket" "artifact_bucket" {
+  project                     = var.project_id
+  name                        = "${var.project_id}-${var.ai_agent_landing_zone_bucket}"
+  location                    = var.main_region
+  uniform_bucket_level_access = true
+  force_destroy               = true
+
+  versioning {
+    enabled = true
+  }
+
+  depends_on = [module.enable_apis]
 }
 
 

--- a/terraform/shared_resources/terraform.tfvars
+++ b/terraform/shared_resources/terraform.tfvars
@@ -1,5 +1,6 @@
-main_region            = "us-central1"
-artifact_registry_name = "mcp-servers"
+main_region                  = "us-central1"
+artifact_registry_name       = "mcp-servers"
+ai_agent_landing_zone_bucket = "ai-agent-landing-zone"
 
 services_to_enable = [
   "cloudresourcemanager.googleapis.com",
@@ -10,3 +11,14 @@ services_to_enable = [
   "bigqueryconnection.googleapis.com",
   "aiplatform.googleapis.com"
 ]
+
+################ Naming Configuration ################
+
+bq_vertex_connection_id       = "vertex_ai_connection"
+bq_dataset_id                 = "knowledge_base"
+bq_chunks_table_id            = "documents_chunks"
+bq_metadata_table_id          = "documents_metadata"
+bq_jobs_table_id              = "ingestion_jobs"
+kb_landing_zone_bucket_suffix = "-kb-landing-zone"
+rag_staging_bucket_suffix     = "-rag-staging"
+kb_domain_bucket_prefix       = "kb-"

--- a/terraform/shared_resources/variables.tf
+++ b/terraform/shared_resources/variables.tf
@@ -24,3 +24,46 @@ variable "services_to_enable" {
   type        = list(string)
   default     = []
 }
+
+variable "ai_agent_landing_zone_bucket" {
+  description = "The name of the global AI Agent landing zone bucket."
+  type        = string
+}
+
+variable "kb_domains" {
+  description = "List of enterprise domains for knowledge base buckets."
+  type        = list(string)
+  default     = ["it", "finance", "hr", "sales", "executives", "legal", "operations"]
+}
+
+variable "bq_vertex_connection_id" {
+  type = string
+}
+
+variable "bq_dataset_id" {
+  type = string
+}
+
+variable "bq_chunks_table_id" {
+  type = string
+}
+
+variable "bq_metadata_table_id" {
+  type = string
+}
+
+variable "bq_jobs_table_id" {
+  type = string
+}
+
+variable "kb_landing_zone_bucket_suffix" {
+  type = string
+}
+
+variable "rag_staging_bucket_suffix" {
+  type = string
+}
+
+variable "kb_domain_bucket_prefix" {
+  type = string
+}


### PR DESCRIPTION
## Overview
This PR completes the migration of foundational data infrastructure (GCS Buckets, BQ Dataset, and Vertex AI Connections) out of the individual pipeline modules and centralizes them into the `shared_resources` module.

It also establishes a universal, strictly enforced `<project-id>-<bucketname>` naming convention (using dashes) for all storage buckets.

## Key Changes
- **Data Foundation Migration**: Moved `kb_landing_zone`, `rag_staging`, `kb_domain_buckets`, and `artifact_bucket` to `shared_resources/main.tf`.
- **BigQuery Centralization**: Extracted the `knowledge_base` dataset, chunk/metadata tables, and Vertex AI connection.
- **Strict Naming Convention**: Enforced the `<project-id>-<bucketname>` standard across all buckets. Replaced underscores with dashes (e.g., `ai-agent-landing-zone`, `kb-it`).
- **Dynamic Parameterization**: Removed all hardcoded names from modules. All identifiers are now passed dynamically via `terraform.tfvars`.
- **Decoupled Architecture**: Eliminates circular or order-dependent deployments. Downstream modules (Pipelines, Agents, MCPs) now simply reference these stable resources.

## Deployment Strategy
1. Deploy `shared_resources` (creates foundation).
2. Deploy `ekb_pipeline_resources` / MCP Servers (binds IAM without dependency errors).
3. Deploy `ai_agent_resources` (creates Agent Service Account).