### PR TITLE
Infrastructure / Prevent BQ connection SA Race Condition

### DIFF
--- a/terraform/shared_resources/main.tf
+++ b/terraform/shared_resources/main.tf
@@ -37,10 +37,17 @@ resource "google_bigquery_connection" "vertex_ai_connection" {
   depends_on = [module.enable_apis]
 }
 
+resource "time_sleep" "wait_for_bq_connection_sa" {
+  depends_on      = [google_bigquery_connection.vertex_ai_connection]
+  create_duration = "30s"
+}
+
 resource "google_project_iam_member" "connection_ai_user" {
   project = var.project_id
   role    = "roles/aiplatform.user"
   member  = "serviceAccount:${google_bigquery_connection.vertex_ai_connection.cloud_resource[0].service_account_id}"
+
+  depends_on = [time_sleep.wait_for_bq_connection_sa]
 }
 
 resource "google_bigquery_dataset" "knowledge_base" {


### PR DESCRIPTION
- Added a 30s `time_sleep` resource after creating the BigQuery Connection.
- Ensures the auto-generated `bqcx-...` service account fully propagates in GCP IAM before attempting to grant it the `roles/aiplatform.user` role.
- Resolves `400 Bad Request: Service account does not exist` errors during fresh deployments.