### PR TITLE
GCP Project Migration- Resolve AI Agent Deployment Errors & EKB pipeline IAM bindings

### DIFF
--- a/terraform/ai_agent_resources/main.tf
+++ b/terraform/ai_agent_resources/main.tf
@@ -12,13 +12,15 @@ module "enable_apis" {
 
 ################ Service Accounts ################
 resource "google_project_service_identity" "vertex_ai_sa" {
-  project = var.project_id
-  service = "aiplatform.googleapis.com"
+  provider = google-beta
+  project  = var.project_id
+  service  = "aiplatform.googleapis.com"
 }
 
 resource "google_project_service_identity" "discovery_engine_sa" {
-  project = var.project_id
-  service = "discoveryengine.googleapis.com"
+  provider = google-beta
+  project  = var.project_id
+  service  = "discoveryengine.googleapis.com"
 }
 
 locals {

--- a/terraform/ai_agent_resources/main.tf
+++ b/terraform/ai_agent_resources/main.tf
@@ -11,9 +11,19 @@ module "enable_apis" {
 
 
 ################ Service Accounts ################
+resource "google_project_service_identity" "vertex_ai_sa" {
+  project = var.project_id
+  service = "aiplatform.googleapis.com"
+}
+
+resource "google_project_service_identity" "discovery_engine_sa" {
+  project = var.project_id
+  service = "discoveryengine.googleapis.com"
+}
+
 locals {
-  vertex_ai_agent_email          = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-aiplatform.iam.gserviceaccount.com"
-  discovery_engine_service_agent = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-discoveryengine.iam.gserviceaccount.com"
+  vertex_ai_agent_email          = "serviceAccount:${google_project_service_identity.vertex_ai_sa.email}"
+  discovery_engine_service_agent = "serviceAccount:${google_project_service_identity.discovery_engine_sa.email}"
 }
 
 module "ai-agent-service-account" {

--- a/terraform/ai_agent_resources/versions.tf
+++ b/terraform/ai_agent_resources/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.17.0, < 8.0.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 7.17.0, < 8.0.0"
+    }
+  }
+}

--- a/terraform/ekb_pipeline_resources/main.tf
+++ b/terraform/ekb_pipeline_resources/main.tf
@@ -75,7 +75,6 @@ module "ekb_pipeline_cloud_run" {
   iam = {
     "roles/run.invoker" = [
       "group:${var.developers_group_email}",
-      "serviceAccount:${var.agent_service_account_email}",
       "serviceAccount:${module.ekb-pipeline-service-account.email}"
     ]
   }


### PR DESCRIPTION
Fixes two issues with the new deployment architecture:
1. Adds `google_project_service_identity` resources to force provisioning of Vertex AI & Discovery Engine managed service accounts before trying to bind roles.
2. Removes explicit `roles/run.invoker` binding for `adk-agent` from `ekb_pipeline_resources` since the pipeline gets deployed *before* the agent, and the agent already receives project-level run.invoker access during its own deployment phase.