### PR TITLE
Refactor: Parameterize Project ID and flatten list structures for Drive and Calendar mcp server deployments

### DIFF
--- a/terraform/drive_mcp_server_resources/README.md
+++ b/terraform/drive_mcp_server_resources/README.md
@@ -139,22 +139,18 @@ To create service accounts, define the service account names and IAM role mappin
 Example:
 
 ```hcl
-project_id             = "mock-project-id"
-main_region            = "us-central1"
 developers_group_email = "my-dev-team@email.com"
 
-apis_to_enable = {
-  "mock-project-id" = [
-    "drive.googleapis.com",
-    "run.googleapis.com",
-    "artifactregistry.googleapis.com"
-  ],
-}
+apis_to_enable = [
+  "drive.googleapis.com",
+  "run.googleapis.com",
+  "artifactregistry.googleapis.com"
+]
 
 mcp_server_service_account_name = "drive-mcp-server"
 
 # Authentication is handled by OAuth token, no project-level roles needed
-mcp_server_iam_project_roles = {}
+mcp_server_iam_project_roles = []
 
 artifact_registry_name         = "mcp-servers"
 mcp_server_cloud_run_name      = "drive-mcp-server"
@@ -166,7 +162,8 @@ mcp_server_cloud_run_image_tag = "latest"
 | Name | Description | Type | Default | Required |
 |---|---|---|---|:---:|
 | `project_id` | The ID of the project where resources are managed. | `string` | n/a | yes |
+| `main_region` | The main region of the project. | `string` | n/a | yes |
 | `developers_group_email` | Google Group email granted `TokenCreator` and `ServiceAccountUser` roles for impersonation. | `string` | n/a | yes |
-| `apis_to_enable` | Service APIs to enable, mapped by project ID. | `map(list(string))` | `{}` | yes |
+| `apis_to_enable` | List of Service APIs to enable in the project. | `list(string)` | `[]` | yes |
 | `mcp_server_service_account_name` | The name of the ADK service account (the part before the @). | `string` | n/a | yes |
-| `mcp_server_iam_project_roles` | Map of project IDs to a list of roles to be assigned to the ADK service account. | `map(list(string))` | `{}` | no |
+| `mcp_server_iam_project_roles` | A list of roles to be assigned to the ADK service account in the project. | `list(string)` | `[]` | no |

--- a/terraform/drive_mcp_server_resources/main.tf
+++ b/terraform/drive_mcp_server_resources/main.tf
@@ -5,7 +5,7 @@ data "google_project" "project" {
 ################ APIs ################
 module "enable_apis" {
   source           = "../base_modules/api-manager"
-  project_services = var.apis_to_enable
+  project_services = { (var.project_id) = var.apis_to_enable }
 }
 
 ################ Service Accounts ################
@@ -20,7 +20,7 @@ module "mcp-server-service-account" {
   }
 
   # non-authoritative roles granted *to* the service account
-  iam_project_roles = var.mcp_server_iam_project_roles
+  iam_project_roles = { (var.project_id) = var.mcp_server_iam_project_roles }
 
   depends_on = [
     module.enable_apis

--- a/terraform/drive_mcp_server_resources/mcp-server-services-cloud-build-cd.yaml
+++ b/terraform/drive_mcp_server_resources/mcp-server-services-cloud-build-cd.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  _LOCATION: us-central1
+  _REGION: us-central1
   _REPO_NAME: mcp-servers
   _SERVICE_NAME: drive-mcp-server
 
@@ -21,6 +21,8 @@ steps:
     id: 'tf-bootstrap'
     args:
       - 'apply'
+      - '-var=project_id=${PROJECT_ID}'
+      - '-var=main_region=${_REGION}'
       - '-target=module.enable_apis'
       - '-auto-approve'
     dir: 'terraform/drive_mcp_server_resources'
@@ -30,8 +32,8 @@ steps:
     id: 'docker-build'
     args: [
       'build',
-      '-t', '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}',
-      '-t', '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest',
+      '-t', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}',
+      '-t', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest',
       '-f', 'mcp_servers/google_drive/Dockerfile',
       '.'
     ]
@@ -43,13 +45,13 @@ steps:
     args:
       - '-c'
       - |
-        docker push ${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}
-        docker push ${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest
+        docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}
+        docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest
 
   # Step 5: Full Terraform Plan
   - name: 'hashicorp/terraform:1.12.2'
     id: 'tf-plan'
-    args: ['plan', '-var=mcp_server_cloud_run_image_tag=${COMMIT_SHA}', '-out=tfplan']
+    args: ['plan', '-var=project_id=${PROJECT_ID}', '-var=main_region=${_REGION}', '-var=mcp_server_cloud_run_image_tag=${COMMIT_SHA}', '-out=tfplan']
     dir: 'terraform/drive_mcp_server_resources'
 
   # Step 6: Full Terraform Apply

--- a/terraform/drive_mcp_server_resources/mcp-server-services-cloud-build-ci.yaml
+++ b/terraform/drive_mcp_server_resources/mcp-server-services-cloud-build-ci.yaml
@@ -53,8 +53,11 @@ steps:
   # Step 7: Plan (Terraform)
   - name: 'hashicorp/terraform:1.12.2'
     id: 'tf-plan'
-    args: ['plan', '-var=mcp_server_cloud_run_image_tag=ci', '-out=tfplan']
+    args: ['plan', '-var=project_id=${PROJECT_ID}', '-var=main_region=${_REGION}', '-var=mcp_server_cloud_run_image_tag=ci', '-out=tfplan']
     dir: 'terraform/drive_mcp_server_resources'
+
+substitutions:
+  _REGION: 'us-central1'
 
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/${_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com'
 

--- a/terraform/drive_mcp_server_resources/terraform.tfvars
+++ b/terraform/drive_mcp_server_resources/terraform.tfvars
@@ -1,26 +1,24 @@
 ################ Project configuration ################
 
-project_id             = "ag-core-ops-auj0"
-main_region            = "us-central1"
+# project_id and main_region are passed dynamically via -var in CI/CD
+
 developers_group_email = "gcu_latam_team_devs@endava.com"
 
 ################ APIs to enable ################
 
-apis_to_enable = {
-  "ag-core-ops-auj0" = [
-    "drive.googleapis.com",
-    "docs.googleapis.com",
-    "run.googleapis.com",
-    "artifactregistry.googleapis.com"
-  ],
-}
+apis_to_enable = [
+  "drive.googleapis.com",
+  "docs.googleapis.com",
+  "run.googleapis.com",
+  "artifactregistry.googleapis.com"
+]
 
 ################ MCP-Server Service Account and IAM Roles ################
 
 mcp_server_service_account_name = "drive-mcp-server"
 
 # Due to authentication is handled by the OAuth token, we don't need any IAM roles for the service account
-mcp_server_iam_project_roles = {}
+mcp_server_iam_project_roles = []
 
 ################ Artifact Registry ################
 

--- a/terraform/drive_mcp_server_resources/variables.tf
+++ b/terraform/drive_mcp_server_resources/variables.tf
@@ -14,9 +14,9 @@ variable "developers_group_email" {
 }
 
 variable "apis_to_enable" {
-  description = "Service APIs to enable, mapped by project ID."
-  type        = map(list(string))
-  default     = {}
+  description = "Service APIs to enable."
+  type        = list(string)
+  default     = []
 }
 
 #Drive mcp-server service account and IAM roles
@@ -27,9 +27,9 @@ variable "mcp_server_service_account_name" {
 }
 
 variable "mcp_server_iam_project_roles" {
-  description = "Map of project IDs to a list of roles to be assigned to the service account."
-  type        = map(list(string))
-  default     = {}
+  description = "A list of roles to be assigned to the service account."
+  type        = list(string)
+  default     = []
 }
 
 ################ Artifact Registry ################

--- a/terraform/google_calendar_mcp_server_resources/README.md
+++ b/terraform/google_calendar_mcp_server_resources/README.md
@@ -59,9 +59,9 @@ chmod +x terraform/scripts/cicd_triggers_creation.sh
 |---|---|---|---|:---:|
 | `project_id` | The ID of the project where resources are managed. | `string` | n/a | yes |
 | `main_region` | The main region to create the resources. | `string` | `"us-central1"` | no |
-| `apis_to_enable` | Service APIs to enable, mapped by project ID. | `map(list(string))` | `{}` | yes |
+| `apis_to_enable` | List of Service APIs to enable in the project. | `list(string)` | `[]` | yes |
 | `mcp_server_service_account_name` | The name of the Service Account created for the Cloud Run instance. | `string` | n/a | yes |
-| `mcp_server_iam_project_roles` | Map of project IDs to a list of roles to be assigned to the Service Account. | `map(list(string))` | `{}` | yes |
+| `mcp_server_iam_project_roles` | A list of roles to be assigned to the Service Account in the project. | `list(string)` | `[]` | yes |
 | `artifact_registry_name` | The name of the Artifact Registry repository holding the Docker images. | `string` | n/a | yes |
 | `mcp_server_cloud_run_name` | The physical name of the GCP Cloud Run service in the console. | `string` | n/a | yes |
 | `mcp_server_cloud_run_image_tag` | The tag/sha of the Docker image to deploy dynamically on Cloud Run. | `string` | n/a | yes |

--- a/terraform/google_calendar_mcp_server_resources/main.tf
+++ b/terraform/google_calendar_mcp_server_resources/main.tf
@@ -5,7 +5,7 @@ data "google_project" "project" {
 ################ APIs ################
 module "enable_apis" {
   source           = "../base_modules/api-manager"
-  project_services = var.apis_to_enable
+  project_services = { (var.project_id) = var.apis_to_enable }
 }
 
 ################ Service Accounts ################
@@ -18,7 +18,7 @@ module "mcp-server-service-account" {
   iam = {}
 
   # non-authoritative roles granted *to* the service account
-  iam_project_roles = var.mcp_server_iam_project_roles
+  iam_project_roles = { (var.project_id) = var.mcp_server_iam_project_roles }
 
   depends_on = [
     module.enable_apis

--- a/terraform/google_calendar_mcp_server_resources/mcp-server-services-cloud-build-cd.yaml
+++ b/terraform/google_calendar_mcp_server_resources/mcp-server-services-cloud-build-cd.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  _LOCATION: us-central1
+  _REGION: us-central1
   _REPO_NAME: mcp-servers
   _SERVICE_NAME: calendar-mcp-server
 
@@ -21,6 +21,8 @@ steps:
     id: 'tf-bootstrap'
     args:
       - 'apply'
+      - '-var=project_id=${PROJECT_ID}'
+      - '-var=main_region=${_REGION}'
       - '-target=module.enable_apis'
       - '-auto-approve'
     dir: 'terraform/google_calendar_mcp_server_resources'
@@ -30,8 +32,8 @@ steps:
     id: 'docker-build'
     args: [
       'build',
-      '-t', '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}',
-      '-t', '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest',
+      '-t', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}',
+      '-t', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest',
       '-f', 'mcp_servers/google_calendar/Dockerfile',
       '.'
     ]
@@ -43,13 +45,13 @@ steps:
     args:
       - '-c'
       - |
-        docker push ${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}
-        docker push ${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest
+        docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${COMMIT_SHA}
+        docker push ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest
 
   # Step 5: Full Terraform Plan
   - name: 'hashicorp/terraform:1.12.2'
     id: 'tf-plan'
-    args: ['plan', '-var=mcp_server_cloud_run_image_tag=${COMMIT_SHA}', '-out=tfplan']
+    args: ['plan', '-var=project_id=${PROJECT_ID}', '-var=main_region=${_REGION}', '-var=mcp_server_cloud_run_image_tag=${COMMIT_SHA}', '-out=tfplan']
     dir: 'terraform/google_calendar_mcp_server_resources'
 
   # Step 6: Full Terraform Apply

--- a/terraform/google_calendar_mcp_server_resources/mcp-server-services-cloud-build-ci.yaml
+++ b/terraform/google_calendar_mcp_server_resources/mcp-server-services-cloud-build-ci.yaml
@@ -1,3 +1,7 @@
+substitutions:
+  _REGION: 'us-central1'
+
+
 steps:
   # Step 1: Initialize Terraform with Dynamic Backend
   - name: 'hashicorp/terraform:1.12.2'
@@ -53,7 +57,7 @@ steps:
   # Step 7: Plan (Terraform)
   - name: 'hashicorp/terraform:1.12.2'
     id: 'tf-plan'
-    args: ['plan', '-var=mcp_server_cloud_run_image_tag=ci', '-out=tfplan']
+    args: ['plan', '-var=project_id=${PROJECT_ID}', '-var=main_region=${_REGION}', '-var=mcp_server_cloud_run_image_tag=ci', '-out=tfplan']
     dir: 'terraform/google_calendar_mcp_server_resources'
 
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/${_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com'

--- a/terraform/google_calendar_mcp_server_resources/terraform.tfvars
+++ b/terraform/google_calendar_mcp_server_resources/terraform.tfvars
@@ -1,23 +1,20 @@
 ################ Project configuration ################
 
-project_id  = "ag-core-ops-auj0"
-main_region = "us-central1"
+# project_id and main_region are passed dynamically via -var in CI/CD
 
 ################ APIs to enable ################
 
-apis_to_enable = {
-  "ag-core-ops-auj0" = [
-    "calendar-json.googleapis.com",
-    "meet.googleapis.com"
-  ],
-}
+apis_to_enable = [
+  "calendar-json.googleapis.com",
+  "meet.googleapis.com"
+]
 
 ################ MCP-Server Service Account and IAM Roles ################
 
 mcp_server_service_account_name = "calendar-mcp-server"
 
 # Due to authentication is handled by the OAuth token, we don't need any IAM roles for the service account
-mcp_server_iam_project_roles = {}
+mcp_server_iam_project_roles = []
 
 ################ Artifact Registry ################
 

--- a/terraform/google_calendar_mcp_server_resources/variables.tf
+++ b/terraform/google_calendar_mcp_server_resources/variables.tf
@@ -12,9 +12,8 @@ variable "main_region" {
 # ----------------- APIs Variable -----------------
 
 variable "apis_to_enable" {
-  description = "A map of project IDs to lists of APIs to enable. Enables standard Google Cloud APIs required for core GCP services."
-  type        = map(list(string))
-  default     = {}
+  type    = list(string)
+  default = []
 }
 
 # ----------------- Service Account Variables -----------------
@@ -26,7 +25,8 @@ variable "mcp_server_service_account_name" {
 
 variable "mcp_server_iam_project_roles" {
   description = "The IAM project roles to grant to the service account."
-  type        = map(list(string))
+  type        = list(string)
+  default     = []
 }
 
 # ----------------- Artifact Registry Variables -----------------


### PR DESCRIPTION
This PR refactors the Drive and Calendar MCP server deployments to be fully parameterized. Project IDs are no longer hardcoded in tfvars and are passed via CI/CD. The list structures for APIs and IAM roles have been flattened from map(list(string)) to list(string) to be consistent with the unified design.