### PR TITLE
EKB Pipeline / Switch Docker image to Alpine to fix 0-day CVE vulnerabilities

### DIFF
--- a/pipelines/enterprise_knowledge_base/Dockerfile
+++ b/pipelines/enterprise_knowledge_base/Dockerfile
@@ -1,22 +1,39 @@
-FROM python:3.12-slim
+ARG UV_VERSION=0.10.7
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv_image
+
+FROM python:3.12-alpine AS builder
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 WORKDIR /app
-
-# Install uv for dependency management
-RUN pip install uv
-
-# Copy project configuration and dependency files
+COPY --from=uv_image /uv /uvx /bin/
 COPY pyproject.toml uv.lock ./
+RUN uv sync --group classification_pipeline --group rag_pipeline --group ekb-integration --no-dev --no-install-project --locked
 
-# Install dependencies globally in the system environment
-RUN uv export --group classification_pipeline --group rag_pipeline --group ekb-integration --no-dev --no-hashes | uv pip install --system -r -
-
-# Copy the necessary pipeline code
 COPY pipelines/__init__.py ./pipelines/
 COPY pipelines/enterprise_knowledge_base/app/ ./pipelines/enterprise_knowledge_base/app/
 
-# Expose the port for Cloud Run
-EXPOSE 8080
+# --- Runtime Stage ---
+FROM python:3.12-alpine
 
-# Run the FastAPI app using uvicorn
-CMD ["uvicorn", "pipelines.enterprise_knowledge_base.app.main:app", "--host", "0.0.0.0", "--port", "8080"]
+WORKDIR /app
+
+RUN adduser -D nonroot
+
+# Remove native package managers to ensure 0 CVEs in scanners (e.g., Artifact Registry)
+RUN rm -rf /usr/local/lib/python3.12/site-packages/pip* \
+           /usr/local/lib/python3.12/site-packages/setuptools* \
+           /usr/local/lib/python3.12/ensurepip \
+           /usr/local/bin/pip*
+
+COPY --from=builder --chown=nonroot:nonroot /app /app
+USER nonroot
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PORT=8080
+
+EXPOSE 8080
+ENTRYPOINT ["uvicorn", "pipelines.enterprise_knowledge_base.app.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## What
Migrates the EKB Pipeline Dockerfile from `python:3.12-slim` to a multi-stage `python:3.12-alpine` build.

## Why
The previous image contained several OS-level vulnerabilities as well as vulnerabilities related to native package managers like `pip` and `setuptools`. 
By switching to `python:3.12-alpine`, we ensure 0 OS-level CVEs. Furthermore, we explicitly remove native Python package managers (`pip`, `setuptools`, `ensurepip`) and their metadata (`.dist-info`) during the build process to guarantee that security scanners (like GCP Artifact Registry) report 0 vulnerabilities.

## Changes
- Updated `pipelines/enterprise_knowledge_base/Dockerfile`.
- Implemented multi-stage build using `ghcr.io/astral-sh/uv` to sync dependencies efficiently.
- Enforced `nonroot` user execution.
- Removed unused native package managers.
- Cleaned up Dockerfile comments for maintainability.