### PR TITLE
EKB Pipeline / Install libstdc++ to support PyMuPDF C-extensions on Alpine

### DIFF
--- a/pipelines/enterprise_knowledge_base/Dockerfile
+++ b/pipelines/enterprise_knowledge_base/Dockerfile
@@ -20,6 +20,9 @@ FROM python:3.12-alpine
 
 WORKDIR /app
 
+# Install required shared libraries (like libstdc++) for C++ extensions such as PyMuPDF
+RUN apk add --no-cache libstdc++
+
 RUN adduser -D nonroot
 
 # Remove native package managers to ensure 0 CVEs in scanners (e.g., Artifact Registry)


### PR DESCRIPTION
## What
Fixes a runtime `ImportError` for `libstdc++.so.6` when running the `ekb-pipeline` Docker image on Alpine Linux.

## Why
When switching the Docker image from `python:3.12-slim` to `python:3.12-alpine` to fix OS-level vulnerabilities, we discovered a runtime issue. The `pymupdf` (fitz) package relies on C++ extensions which are dynamically linked against GNU's standard C++ library (`libstdc++`). Since Alpine Linux uses `musl libc` and is ultra-minimalist, it does not include this library by default, causing the container to crash on startup.

## How it was solved
- We updated the `pipelines/enterprise_knowledge_base/Dockerfile` to explicitly install the missing C++ library in the runtime stage using `apk add --no-cache libstdc++`.
- This satisfies the shared library dependency for `pymupdf` while maintaining the zero-CVE footprint of the Alpine image.