### PR TITLE
Gemini Enterprise/Microsoft Auth Validation

### DIFF
--- a/agent/core_agent/config/agent_settings.py
+++ b/agent/core_agent/config/agent_settings.py
@@ -207,7 +207,7 @@ You are the primary interface for the user. Your objective is to analyze the use
 </core_directive>
 
 <routing_rules>
-- **Deep Research, Meetings & Connected Sources**: Delegate to the `research_specialist` when the user asks for meeting summaries, deep research, document searches, or any SharePoint/Drive/Jira/Calendar/Confluence operation.
+- **Deep Research, Meetings & Connected Sources**: Delegate to the `research_specialist` when the user asks for meeting summaries, deep research, document searches, or any SharePoint/OneDrive/Google Drive/Jira/Calendar/Confluence/BigQuery/Cloud Storage operation.
 - **File Uploads for Analysis**: If the user uploads a file and asks a question about it, use `get_artifact_uri` to retrieve its GCS URI. Pass this URI explicitly when delegating to the `research_specialist`.
 - **Ingestion & Status**: Delegate to the `ingestion_specialist` when the user wants to ingest a file into the EKB or check an ingestion status.
 </routing_rules>

--- a/docs/Authentication/06-Microsoft-Entra-Setup.md
+++ b/docs/Authentication/06-Microsoft-Entra-Setup.md
@@ -14,66 +14,61 @@ Follow these steps to configure the application, generate credentials, and grant
 3. Click on **New registration**.
 4. **Name**: Provide a descriptive name for your application (e.g., `Research-Agent-Connectors`).
 5. **Supported account types**: Select **Accounts in this organizational directory only (Single tenant)**.
-6. **Redirect URI**: Select **Web** from the dropdown and add the Gemini Enterprise URLs:
-   - `https://vertexaisearch.cloud.google.com/static/oauth/oauth.html`
-   - `https://vertexaisearch.cloud.google.com/oauth-redirect`
-   > **Why "Web"?** Microsoft enforces a strict security profile for Web URIs, demanding a `client_secret` to complete the login. Gemini Enterprise runs securely in the backend and provides this secret.
-7. Click **Register**.
-8. After registration, click **Authentication** in the left menu.
-9. Click **+ Add a platform**, select **Mobile and desktop applications**, and add your local testing URIs (e.g., `http://localhost:8000`, `http://localhost:8000/dev-ui/`).
-   > **Why "Mobile and desktop"?** This bucket is for "Public Clients" (like local Jupyter notebooks). It proves identity using PKCE instead of a `client_secret`. Local tools cannot securely hold a secret, so they must use this platform type to authenticate!
-10. Scroll down to **Advanced settings** and toggle **Allow public client flows** to **Yes** (and hit Save). This ensures local public browser flows are not blocked.
+6. Click **Register**.
 
-## 2. Gather Credentials
-
-Once the application is registered, you will be directed to its overview page.
-1. Copy the **Application (client) ID**. This is your `Client ID`.
-2. Copy the **Directory (tenant) ID**. This is your `Tenant ID`.
-
-## 3. Generate a Client Secret
+## 2. Generate a Client Secret
 
 1. Under the **Manage** menu on the left, click **Certificates & secrets**.
 2. Go to the **Client secrets** tab and click **New client secret**.
-3. Add a description (e.g., `Agent MCP Secret`) and select an expiration period.
-4. Click **Add**.
-5. **CRITICAL**: Copy the **Secret Value** immediately. This value will be hidden once you navigate away from this page. This is your `Client Secret`.
+3. Add a description (e.g., `Agent MCP Secret`).
+4. **Expires**: Select **1 year** (recommended) or at least **6 months**.
+5. Click **Add**.
+6. **CRITICAL**: Copy the **Secret Value** immediately. This value will be hidden once you navigate away from this page. This is your `CLIENT_SECRET`.
 
-## 4. Define API Permissions (Scopes)
-
-You need to grant **Delegated permissions** (since the agent acts on behalf of the user via an OAuth flow) to read files and content from the various Microsoft services.
+## 3. Define API Permissions (Scopes)
 
 1. Under the **Manage** menu, click **API permissions**.
 2. Click **Add a permission** > **Microsoft Graph** > **Delegated permissions**.
-3. Search for and check the following permissions based on the connectors you want to enable:
-
-### General (Mandatory)
-- `offline_access`: Required to grant Google / the Agent a refresh token. This ensures the connection stays active without requiring the user to constantly re-authenticate.
-- `User.Read`: Basic profile reading required for token validation.
-
-### OneDrive & SharePoint
-*(Note: Files shared in Microsoft Teams are physically stored in SharePoint and OneDrive. These permissions cover those files as well.)*
-- `Files.Read.All`: Allows reading all files the signed-in user has access to.
-- `Sites.Read.All`: Allows reading all SharePoint site items and lists the signed-in user has access to.
-
-### Outlook
-- `Mail.Read`: Allows reading the user's email messages.
-- `Mail.Read.Shared`: *(Optional)* Allows reading email in shared folders or delegated mailboxes if your agent needs that capability.
-
-### Microsoft Teams
-- `Team.ReadBasic.All`: Allows the application to list the Teams the user is a member of.
-- `Channel.ReadBasic.All`: Allows the application to list the channels within those Teams.
-- `ChannelMessage.Read.All`: Allows reading messages in channels the user has access to.
-- `Chat.Read`: Allows reading 1-on-1 and group chat messages.
-
+3. Search for and check the following permissions:
+   - `Files.Read.All` (Include the services that will be used, like SharePoint, OneDrive, Outlook)
+   - `Sites.Read.All`
+   - `User.Read` (to correctly authenticate to the MCPs)
+   - `offline_access`
+   - `email`
+   - `Mail.Read`
+   - `Mail.Read.Shared`
 4. Once all the required permissions are checked, click **Add permissions** at the bottom.
 
-## 5. Grant Admin Consent
+## 4. Grant Admin Consent
 
-To prevent users from being blocked by corporate policies that require administrator approval for these specific scopes:
+To prevent users from being blocked by corporate policies:
 1. On the **API permissions** page, click the **Grant admin consent for [Your Tenant Name]** button located above the permissions list.
-2. Confirm the action. The status column for all permissions should change to a green checkmark indicating "Granted".
+2. Confirm the action. Make sure to grant admin consent on all of them (the status column should show a green checkmark).
 
----
+## 5. Configure Authentication (Redirect URLs)
+
+1. Under the **Manage** menu, click **Authentication**.
+2. Click **Add a platform** and select **Web**.
+3. Include the following Redirect URLs:
+   - `http://localhost:8000/dev-ui/` -> For local testing with ADK
+   - `https://vertexaisearch.cloud.google.com/static/oauth/oauth.html` -> For GE
+   - `https://vertexaisearch.cloud.google.com/oauth-redirect` -> For GE
+4. Click **Configure** and save the changes.
+
+## 6. Mandatory: Enterprise Applications Admin Consent
+
+1. Navigate to **Identity** > **Applications** > **Enterprise applications**.
+2. Search for and select the application you just registered.
+3. In the left menu, under **Security**, click on **Permissions**.
+4. Click the button to **Grant admin consent for [Your Tenant Name]**.
+
+## 7. Store Credentials
 
 > [!IMPORTANT]
-> Store the **Client ID**, **Client Secret**, and **Tenant ID** securely (e.g., inside Google Secret Manager or your local `.env` file). These values must not be committed to version control and will be passed to your `config.py` as environment variables for the MCP Server.
+> Store the **CLIENT_ID**, **TENANT_ID**, and **CLIENT_SECRET** securely. These will be used in the GE auth resources and local `.env` files.
+
+## 8. Gemini Enterprise Auth Configuration Note
+
+When creating the Auth ID in Gemini Enterprise for this Microsoft Entra application, ensure that you set the prompt parameter to `select_account` (as defined in the CI/CD pipelines) instead of the default `consent`.
+
+> **Why?** If the prompt is set to `consent`, Microsoft Entra ID will attempt to force the user to re-consent to the permissions every time they log in. Since these are enterprise-level scopes, a regular user will hit a "Needs admin approval" error screen and get blocked. By granting Admin Consent globally (Step 6) and using `prompt=select_account`, the user simply picks their Microsoft account and the authentication succeeds silently without asking for consent again.

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
@@ -111,7 +111,8 @@ steps:
           --client-secret "$$MICROSOFT_OAUTH_CLIENT_SECRET" \
           --scopes "${_MICROSOFT_OAUTH_SCOPES}" \
           --auth-uri-base "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/authorize" \
-          --token-uri "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/token"
+          --token-uri "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/token" \
+          --prompt "select_account"
 
   
   # Step 6: Deploy the AI-Agent to Agent Engine

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
@@ -15,11 +15,17 @@ substitutions:
   _METRICS_TABLE_ID: "response_times"
   _GE_APP_ID: "gemini-enterprise-17816266_1781626607357"
   _GE_REGION: "global"
-  _GE_AGENT_DESCRIPTION: "OSIRIS - Organizational Search, Information Retrieval, and Intelligence System: A hierarchical multi-agent system designed to break information silos by searching across BigQuery, GCS, Google Drive, and Google Calendar, and managing EKB document ingestion."
+  _GE_AGENT_DESCRIPTION: "OSIRIS: A hierarchical multi-agent system designed to break information silos and search across enterprise data sources."
   _GOOGLE_OAUTH_SCOPES: "openid email https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/calendar.events.readonly https://www.googleapis.com/auth/meetings.space.readonly"
   _MICROSOFT_OAUTH_SCOPES: "offline_access Files.Read.All Sites.Read.All"
   _MICROSOFT_TENANT_ID: "93f8f3d2-54f6-417d-9a37-10ff2952f228"
-  
+  _GEMINI_GOOGLE_AUTH_ID: "google-workspace-authentication"
+  _GEMINI_MICROSOFT_AUTH_ID: "microsoft-entra-authentication"
+
+  # Test Agent Variables
+  _TEST_AGENT_DISPLAY_NAME: "OSIRIS - Test"
+  _TEST_GOOGLE_AUTH_ID: "google-workspace-authentication-test"
+  _TEST_MICROSOFT_AUTH_ID: "microsoft-entra-authentication-test"
 
 steps:
   # Step 1: Initialize Terraform with Dynamic Backend
@@ -45,7 +51,54 @@ steps:
       - '-auto-approve'
     dir: 'terraform/ai_agent_resources'
   
-  # Step 3: Unregister the agent from GE
+  # Step 3: Unregister the test agent from GE
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'ge-unregister-test-agent'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        apt-get update && apt-get install -y jq curl
+        chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
+        
+        echo "Deleting test agent in GE..."
+        ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh delete-agent \
+          --project ${PROJECT_ID} \
+          --ge-location ${_GE_REGION} \
+          --app-id ${_GE_APP_ID} \
+          --agent-display-name "${_TEST_AGENT_DISPLAY_NAME}" || true
+
+  # Step 4: Delete test auth IDs
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'ge-delete-test-auth-resources'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        apt-get update && apt-get install -y jq curl
+        chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
+
+        echo "Deleting Test GE Auth IDs..."
+        ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh delete-auth-ids \
+          --project ${PROJECT_ID} \
+          --ge-location ${_GE_REGION} \
+          --auth-ids "${_TEST_GOOGLE_AUTH_ID},${_TEST_MICROSOFT_AUTH_ID}" || true
+
+  # Step 5: Delete test agent from Agent Engine
+  - name: 'python:3.12'
+    id: 'delete-test-agent-engine'
+    entrypoint: 'sh'
+    args:
+      - '-c'
+      - |
+        pip install google-cloud-aiplatform click loguru
+        echo "Deleting test agent engine..."
+        python terraform/ai_agent_resources/scripts/delete_agent_engine.py \
+          --project ${PROJECT_ID} \
+          --location ${_REGION} \
+          --display-name "${_TEST_AGENT_DISPLAY_NAME}" || true
+
+  # Step 6: Unregister the agent from GE
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-unregister-agent'
     entrypoint: 'bash'
@@ -62,39 +115,38 @@ steps:
           --app-id ${_GE_APP_ID} \
           --agent-display-name "${_AGENT_DISPLAY_NAME}"
 
-  # Step 4: Delete all auth resources
+  # Step 7: Delete all auth resources
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-delete-auth-resources'
     entrypoint: 'bash'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
     args:
       - '-c'
       - |
         apt-get update && apt-get install -y jq curl
         chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
 
-        echo "Deleting GE Auth IDs $$GEMINI_GOOGLE_AUTH_ID and $$GEMINI_MICROSOFT_AUTH_ID..."
+        echo "Deleting GE Auth IDs ${_GEMINI_GOOGLE_AUTH_ID} and ${_GEMINI_MICROSOFT_AUTH_ID}..."
         ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh delete-auth-ids \
           --project ${PROJECT_ID} \
           --ge-location ${_GE_REGION} \
-          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID,$$GEMINI_MICROSOFT_AUTH_ID"
+          --auth-ids "${_GEMINI_GOOGLE_AUTH_ID},${_GEMINI_MICROSOFT_AUTH_ID}"
 
-  # Step 5: Create new auth resources
+  # Step 8: Create new auth resources
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-create-auth-resources'
     entrypoint: 'bash'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET', 'GEMINI_MICROSOFT_AUTH_ID', 'MICROSOFT_OAUTH_CLIENT_ID', 'MICROSOFT_OAUTH_CLIENT_SECRET']
+    secretEnv: ['GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET', 'MICROSOFT_OAUTH_CLIENT_ID', 'MICROSOFT_OAUTH_CLIENT_SECRET']
     args:
       - '-c'
       - |
         apt-get update && apt-get install -y jq curl
         chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
 
-        echo "Creating GE Auth ID for Google: $$GEMINI_GOOGLE_AUTH_ID..."
+        echo "Creating GE Auth ID for Google: ${_GEMINI_GOOGLE_AUTH_ID}..."
         ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh create-auth-ids \
           --project ${PROJECT_ID} \
           --ge-location ${_GE_REGION} \
-          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID" \
+          --auth-ids "${_GEMINI_GOOGLE_AUTH_ID}" \
           --client-id "$$GOOGLE_OAUTH_CLIENT_ID" \
           --client-secret "$$GOOGLE_OAUTH_CLIENT_SECRET" \
           --scopes "${_GOOGLE_OAUTH_SCOPES}" \
@@ -102,11 +154,11 @@ steps:
           --token-uri "https://oauth2.googleapis.com/token" \
           --auth-uri-extras "include_granted_scopes=true&access_type=offline"
 
-        echo "Creating GE Auth ID for Microsoft: $$GEMINI_MICROSOFT_AUTH_ID..."
+        echo "Creating GE Auth ID for Microsoft: ${_GEMINI_MICROSOFT_AUTH_ID}..."
         ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh create-auth-ids \
           --project ${PROJECT_ID} \
           --ge-location ${_GE_REGION} \
-          --auth-ids "$$GEMINI_MICROSOFT_AUTH_ID" \
+          --auth-ids "${_GEMINI_MICROSOFT_AUTH_ID}" \
           --client-id "$$MICROSOFT_OAUTH_CLIENT_ID" \
           --client-secret "$$MICROSOFT_OAUTH_CLIENT_SECRET" \
           --scopes "${_MICROSOFT_OAUTH_SCOPES}" \
@@ -115,11 +167,10 @@ steps:
           --prompt "select_account"
 
   
-  # Step 6: Deploy the AI-Agent to Agent Engine
+  # Step 9: Deploy the AI-Agent to Agent Engine
   - name: 'python:3.12'
     id: 'deploy-agent-engine'
     entrypoint: 'sh'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
     args:
       - '-c'
       - |
@@ -141,17 +192,16 @@ steps:
           --min-instances=1 \
           --memory=16Gi \
           --num-workers=4 \
-          --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},LANDING_ZONE_BUCKET=${PROJECT_ID}-ai-agent-landing-zone,MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GCS_URL=${_GCS_URL},CALENDAR_URL=${_CALENDAR_URL},GEMINI_GOOGLE_AUTH_ID=$$GEMINI_GOOGLE_AUTH_ID,GEMINI_MICROSOFT_AUTH_ID=$$GEMINI_MICROSOFT_AUTH_ID,ONEDRIVE_URL=${_ONEDRIVE_URL},ATLASSIAN_URL=${_ATLASSIAN_URL},SHAREPOINT_URL=${_SHAREPOINT_URL},EKB_PIPELINE_URL=${_EKB_PIPELINE_URL},METRICS_PROJECT_ID=${PROJECT_ID},METRICS_DATASET_ID=${_METRICS_DATASET_ID},METRICS_TABLE_ID=${_METRICS_TABLE_ID}" 2>&1 | tee deploy_output.txt
+          --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},LANDING_ZONE_BUCKET=${PROJECT_ID}-ai-agent-landing-zone,MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GCS_URL=${_GCS_URL},CALENDAR_URL=${_CALENDAR_URL},GEMINI_GOOGLE_AUTH_ID=${_GEMINI_GOOGLE_AUTH_ID},GEMINI_MICROSOFT_AUTH_ID=${_GEMINI_MICROSOFT_AUTH_ID},ONEDRIVE_URL=${_ONEDRIVE_URL},ATLASSIAN_URL=${_ATLASSIAN_URL},SHAREPOINT_URL=${_SHAREPOINT_URL},EKB_PIPELINE_URL=${_EKB_PIPELINE_URL},METRICS_PROJECT_ID=${PROJECT_ID},METRICS_DATASET_ID=${_METRICS_DATASET_ID},METRICS_TABLE_ID=${_METRICS_TABLE_ID}" 2>&1 | tee deploy_output.txt
         
         grep -o "reasoningEngines/[0-9]*" deploy_output.txt | tail -n 1 | cut -d'/' -f2 > /workspace/adk_resource.txt
         echo "Captured ADK_RESOURCE_ID: $(cat /workspace/adk_resource.txt)"
 
 
-  # Step 7: Register the Agent in GE
+  # Step 10: Register the Agent in GE
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-register-agent'
     entrypoint: 'bash'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
     args:
       - '-c'
       - |
@@ -172,18 +222,14 @@ steps:
           --agent-description "${_GE_AGENT_DESCRIPTION}" \
           --agent-engine-location ${_REGION} \
           --agent-engine-agent-id "$${ADK_RESOURCE_ID}" \
-          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID,$$GEMINI_MICROSOFT_AUTH_ID"
+          --auth-ids "${_GEMINI_GOOGLE_AUTH_ID},${_GEMINI_MICROSOFT_AUTH_ID}"
 
 availableSecrets:
   secretManager:
-    - versionName: projects/${PROJECT_ID}/secrets/GEMINI_GOOGLE_AUTH_ID/versions/latest
-      env: 'GEMINI_GOOGLE_AUTH_ID'
     - versionName: projects/${PROJECT_ID}/secrets/GOOGLE_OAUTH_CLIENT_ID/versions/latest
       env: 'GOOGLE_OAUTH_CLIENT_ID'
     - versionName: projects/${PROJECT_ID}/secrets/GOOGLE_OAUTH_CLIENT_SECRET/versions/latest
       env: 'GOOGLE_OAUTH_CLIENT_SECRET'
-    - versionName: projects/${PROJECT_ID}/secrets/GEMINI_MICROSOFT_AUTH_ID/versions/latest
-      env: 'GEMINI_MICROSOFT_AUTH_ID'
     - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_ID/versions/latest
       env: 'MICROSOFT_OAUTH_CLIENT_ID'
     - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_SECRET/versions/latest

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-cd.yaml
@@ -19,8 +19,8 @@ substitutions:
   _GOOGLE_OAUTH_SCOPES: "openid email https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/calendar.events.readonly https://www.googleapis.com/auth/meetings.space.readonly"
   _MICROSOFT_OAUTH_SCOPES: "offline_access Files.Read.All Sites.Read.All"
   _MICROSOFT_TENANT_ID: "93f8f3d2-54f6-417d-9a37-10ff2952f228"
-  _GEMINI_GOOGLE_AUTH_ID: "google-workspace-authentication"
-  _GEMINI_MICROSOFT_AUTH_ID: "microsoft-entra-authentication"
+  _GEMINI_GOOGLE_AUTH_ID: "ge-google-prod" #  - This auth ID will be renamed to "google-workspace-authentication" after the submit happens
+  _GEMINI_MICROSOFT_AUTH_ID: "ge-microsoft-prod" # - This auth ID will be renamed to "microsoft-entra-authentication" after the submit happens
 
   # Test Agent Variables
   _TEST_AGENT_DISPLAY_NAME: "OSIRIS - Test"

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
@@ -15,12 +15,12 @@ substitutions:
   _METRICS_TABLE_ID: "response_times"
   _GE_APP_ID: "gemini-enterprise-17816266_1781626607357"
   _GE_REGION: "global"
-  _GE_AGENT_DESCRIPTION: "OSIRIS - Organizational Search, Information Retrieval, and Intelligence System: A hierarchical multi-agent system designed to break information silos by searching across BigQuery, GCS, Google Drive, and Google Calendar, and managing EKB document ingestion."
+  _GE_AGENT_DESCRIPTION: "OSIRIS: A hierarchical multi-agent system designed to break information silos and search across enterprise data sources."
   _GOOGLE_OAUTH_SCOPES: "openid email https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/calendar.events.readonly https://www.googleapis.com/auth/meetings.space.readonly"
   _MICROSOFT_OAUTH_SCOPES: "offline_access Files.Read.All Sites.Read.All User.Read"
   _MICROSOFT_TENANT_ID: "93f8f3d2-54f6-417d-9a37-10ff2952f228"
   _GEMINI_GOOGLE_AUTH_ID: "google-workspace-authentication-test"
-  _GEMINI_MICROSOFT_AUTH_ID: "microsoft-work-authentication-test"
+  _GEMINI_MICROSOFT_AUTH_ID: "microsoft-entra-authentication-test"
 
 steps:
   # Step 1: Initialize Terraform with Dynamic Backend
@@ -35,7 +35,42 @@ steps:
           -backend-config="prefix=terraform/state/ai-agent-resources"
     dir: 'terraform/ai_agent_resources'
 
-  # Step 2: Run Terraform Apply
+  # Step 2: Ensure code is formatted correctly
+  - name: 'hashicorp/terraform:1.12.2'
+    id: 'tf-fmt'
+    args: ['fmt', '-check']
+    dir: 'terraform/ai_agent_resources'
+
+  # Step 3: Format Check & Tests (Python)
+  - name: 'python:3.12'
+    id: 'python-lint-and-tests'
+    entrypoint: 'sh'
+    args:
+      - '-c'
+      - |
+        apt-get update && apt-get install -y make
+        pip install uv
+        uv sync --group ai-agent --group dev
+        make run-agent-precommit
+        make test-agent
+
+  # Step 4: Validate the configuration syntax
+  - name: 'hashicorp/terraform:1.12.2'
+    id: 'tf-validate'
+    args: ['validate']
+    dir: 'terraform/ai_agent_resources'
+
+  # Step 5: Run Terraform Plan
+  - name: 'hashicorp/terraform:1.12.2'
+    id: 'tf-plan'
+    args:
+      - 'plan'
+      - '-var=project_id=${PROJECT_ID}'
+      - '-var=main_region=${_REGION}'
+      - '-out=tfplan'
+    dir: 'terraform/ai_agent_resources'
+
+  # Step 6: Run Terraform Apply
   # Creates the required permissions and service accounts to run the agent
   - name: 'hashicorp/terraform:1.12.2'
     id: 'tf-apply'
@@ -46,7 +81,7 @@ steps:
       - '-auto-approve'
     dir: 'terraform/ai_agent_resources'
   
-  # Step 3: Unregister the agent from GE
+  # Step 7: Unregister the agent from GE
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-unregister-agent'
     entrypoint: 'bash'
@@ -63,7 +98,7 @@ steps:
           --app-id ${_GE_APP_ID} \
           --agent-display-name "${_AGENT_DISPLAY_NAME}"
 
-  # Step 4: Delete all auth resources
+  # Step 8: Delete all auth resources
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-delete-auth-resources'
     entrypoint: 'bash'
@@ -79,11 +114,11 @@ steps:
           --ge-location ${_GE_REGION} \
           --auth-ids "${_GEMINI_GOOGLE_AUTH_ID},${_GEMINI_MICROSOFT_AUTH_ID}"
 
-  # Step 5: Create new auth resources
+  # Step 9: Create new auth resources
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-create-auth-resources'
     entrypoint: 'bash'
-    secretEnv: ['GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET', 'MICROSOFT_OAUTH_CLIENT_ID_TEST', 'MICROSOFT_OAUTH_CLIENT_SECRET_TEST']
+    secretEnv: ['GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET', 'MICROSOFT_OAUTH_CLIENT_ID', 'MICROSOFT_OAUTH_CLIENT_SECRET']
     args:
       - '-c'
       - |
@@ -107,15 +142,15 @@ steps:
           --project ${PROJECT_ID} \
           --ge-location ${_GE_REGION} \
           --auth-ids "${_GEMINI_MICROSOFT_AUTH_ID}" \
-          --client-id "$$MICROSOFT_OAUTH_CLIENT_ID_TEST" \
-          --client-secret "$$MICROSOFT_OAUTH_CLIENT_SECRET_TEST" \
+          --client-id "$$MICROSOFT_OAUTH_CLIENT_ID" \
+          --client-secret "$$MICROSOFT_OAUTH_CLIENT_SECRET" \
           --scopes "${_MICROSOFT_OAUTH_SCOPES}" \
           --auth-uri-base "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/authorize" \
           --token-uri "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/token" \
           --prompt "select_account"
 
   
-  # Step 6: Deploy the AI-Agent to Agent Engine
+  # Step 10: Deploy the AI-Agent to Agent Engine
   - name: 'python:3.12'
     id: 'deploy-agent-engine'
     entrypoint: 'sh'
@@ -146,7 +181,7 @@ steps:
         echo "Captured ADK_RESOURCE_ID: $(cat /workspace/adk_resource.txt)"
 
 
-  # Step 7: Register the Agent in GE
+  # Step 11: Register the Agent in GE
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-register-agent'
     entrypoint: 'bash'
@@ -178,10 +213,10 @@ availableSecrets:
       env: 'GOOGLE_OAUTH_CLIENT_ID'
     - versionName: projects/${PROJECT_ID}/secrets/GOOGLE_OAUTH_CLIENT_SECRET/versions/latest
       env: 'GOOGLE_OAUTH_CLIENT_SECRET'
-    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_ID_TEST/versions/latest
-      env: 'MICROSOFT_OAUTH_CLIENT_ID_TEST'
-    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_SECRET_TEST/versions/latest
-      env: 'MICROSOFT_OAUTH_CLIENT_SECRET_TEST'
+    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_ID/versions/latest
+      env: 'MICROSOFT_OAUTH_CLIENT_ID'
+    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_SECRET/versions/latest
+      env: 'MICROSOFT_OAUTH_CLIENT_SECRET'
 
 
 # Ensure this Service Account has 'Storage Object Admin' on the state bucket

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
@@ -1,6 +1,6 @@
 substitutions:
   _REGION: "us-central1"
-  _AGENT_DISPLAY_NAME: "OSIRIS"
+  _AGENT_DISPLAY_NAME: "OSIRIS - Test"
   _MODEL_ARMOR_TEMPLATE_ID: "security-template"
   _AGENT_SA: "adk-agent"
   _BIGQUERY_URL: "https://bigquery-mcp-server-1057005221381.us-central1.run.app"
@@ -19,7 +19,8 @@ substitutions:
   _GOOGLE_OAUTH_SCOPES: "openid email https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/calendar.events.readonly https://www.googleapis.com/auth/meetings.space.readonly"
   _MICROSOFT_OAUTH_SCOPES: "offline_access Files.Read.All Sites.Read.All"
   _MICROSOFT_TENANT_ID: "93f8f3d2-54f6-417d-9a37-10ff2952f228"
-  
+  _GEMINI_GOOGLE_AUTH_ID: "google-workspace-authentication-test"
+  _GEMINI_MICROSOFT_AUTH_ID: "microsoft-work-authentication-test"
 
 steps:
   # Step 1: Initialize Terraform with Dynamic Backend
@@ -66,35 +67,34 @@ steps:
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-delete-auth-resources'
     entrypoint: 'bash'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
     args:
       - '-c'
       - |
         apt-get update && apt-get install -y jq curl
         chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
 
-        echo "Deleting GE Auth IDs $$GEMINI_GOOGLE_AUTH_ID and $$GEMINI_MICROSOFT_AUTH_ID..."
+        echo "Deleting GE Auth IDs ${_GEMINI_GOOGLE_AUTH_ID} and ${_GEMINI_MICROSOFT_AUTH_ID}..."
         ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh delete-auth-ids \
           --project ${PROJECT_ID} \
           --ge-location ${_GE_REGION} \
-          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID,$$GEMINI_MICROSOFT_AUTH_ID"
+          --auth-ids "${_GEMINI_GOOGLE_AUTH_ID},${_GEMINI_MICROSOFT_AUTH_ID}"
 
   # Step 5: Create new auth resources
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-create-auth-resources'
     entrypoint: 'bash'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET', 'GEMINI_MICROSOFT_AUTH_ID', 'MICROSOFT_OAUTH_CLIENT_ID', 'MICROSOFT_OAUTH_CLIENT_SECRET']
+    secretEnv: ['GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET', 'MICROSOFT_OAUTH_CLIENT_ID_TEST', 'MICROSOFT_OAUTH_CLIENT_SECRET_TEST']
     args:
       - '-c'
       - |
         apt-get update && apt-get install -y jq curl
         chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
 
-        echo "Creating GE Auth ID for Google: $$GEMINI_GOOGLE_AUTH_ID..."
+        echo "Creating GE Auth ID for Google: ${_GEMINI_GOOGLE_AUTH_ID}..."
         ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh create-auth-ids \
           --project ${PROJECT_ID} \
           --ge-location ${_GE_REGION} \
-          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID" \
+          --auth-ids "${_GEMINI_GOOGLE_AUTH_ID}" \
           --client-id "$$GOOGLE_OAUTH_CLIENT_ID" \
           --client-secret "$$GOOGLE_OAUTH_CLIENT_SECRET" \
           --scopes "${_GOOGLE_OAUTH_SCOPES}" \
@@ -102,13 +102,13 @@ steps:
           --token-uri "https://oauth2.googleapis.com/token" \
           --auth-uri-extras "include_granted_scopes=true&access_type=offline"
 
-        echo "Creating GE Auth ID for Microsoft: $$GEMINI_MICROSOFT_AUTH_ID..."
+        echo "Creating GE Auth ID for Microsoft: ${_GEMINI_MICROSOFT_AUTH_ID}..."
         ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh create-auth-ids \
           --project ${PROJECT_ID} \
           --ge-location ${_GE_REGION} \
-          --auth-ids "$$GEMINI_MICROSOFT_AUTH_ID" \
-          --client-id "$$MICROSOFT_OAUTH_CLIENT_ID" \
-          --client-secret "$$MICROSOFT_OAUTH_CLIENT_SECRET" \
+          --auth-ids "${_GEMINI_MICROSOFT_AUTH_ID}" \
+          --client-id "$$MICROSOFT_OAUTH_CLIENT_ID_TEST" \
+          --client-secret "$$MICROSOFT_OAUTH_CLIENT_SECRET_TEST" \
           --scopes "${_MICROSOFT_OAUTH_SCOPES}" \
           --auth-uri-base "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/authorize" \
           --token-uri "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/token" \
@@ -119,7 +119,6 @@ steps:
   - name: 'python:3.12'
     id: 'deploy-agent-engine'
     entrypoint: 'sh'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
     args:
       - '-c'
       - |
@@ -141,7 +140,7 @@ steps:
           --min-instances=1 \
           --memory=16Gi \
           --num-workers=4 \
-          --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},LANDING_ZONE_BUCKET=${PROJECT_ID}-ai-agent-landing-zone,MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GCS_URL=${_GCS_URL},CALENDAR_URL=${_CALENDAR_URL},GEMINI_GOOGLE_AUTH_ID=$$GEMINI_GOOGLE_AUTH_ID,GEMINI_MICROSOFT_AUTH_ID=$$GEMINI_MICROSOFT_AUTH_ID,ONEDRIVE_URL=${_ONEDRIVE_URL},ATLASSIAN_URL=${_ATLASSIAN_URL},SHAREPOINT_URL=${_SHAREPOINT_URL},EKB_PIPELINE_URL=${_EKB_PIPELINE_URL},METRICS_PROJECT_ID=${PROJECT_ID},METRICS_DATASET_ID=${_METRICS_DATASET_ID},METRICS_TABLE_ID=${_METRICS_TABLE_ID}" 2>&1 | tee deploy_output.txt
+          --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},LANDING_ZONE_BUCKET=${PROJECT_ID}-ai-agent-landing-zone,MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GCS_URL=${_GCS_URL},CALENDAR_URL=${_CALENDAR_URL},GEMINI_GOOGLE_AUTH_ID=${_GEMINI_GOOGLE_AUTH_ID},GEMINI_MICROSOFT_AUTH_ID=${_GEMINI_MICROSOFT_AUTH_ID},ONEDRIVE_URL=${_ONEDRIVE_URL},ATLASSIAN_URL=${_ATLASSIAN_URL},SHAREPOINT_URL=${_SHAREPOINT_URL},EKB_PIPELINE_URL=${_EKB_PIPELINE_URL},METRICS_PROJECT_ID=${PROJECT_ID},METRICS_DATASET_ID=${_METRICS_DATASET_ID},METRICS_TABLE_ID=${_METRICS_TABLE_ID}" 2>&1 | tee deploy_output.txt
         
         grep -o "reasoningEngines/[0-9]*" deploy_output.txt | tail -n 1 | cut -d'/' -f2 > /workspace/adk_resource.txt
         echo "Captured ADK_RESOURCE_ID: $(cat /workspace/adk_resource.txt)"
@@ -151,7 +150,6 @@ steps:
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'ge-register-agent'
     entrypoint: 'bash'
-    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
     args:
       - '-c'
       - |
@@ -172,22 +170,18 @@ steps:
           --agent-description "${_GE_AGENT_DESCRIPTION}" \
           --agent-engine-location ${_REGION} \
           --agent-engine-agent-id "$${ADK_RESOURCE_ID}" \
-          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID,$$GEMINI_MICROSOFT_AUTH_ID"
+          --auth-ids "${_GEMINI_GOOGLE_AUTH_ID},${_GEMINI_MICROSOFT_AUTH_ID}"
 
 availableSecrets:
   secretManager:
-    - versionName: projects/${PROJECT_ID}/secrets/GEMINI_GOOGLE_AUTH_ID/versions/latest
-      env: 'GEMINI_GOOGLE_AUTH_ID'
     - versionName: projects/${PROJECT_ID}/secrets/GOOGLE_OAUTH_CLIENT_ID/versions/latest
       env: 'GOOGLE_OAUTH_CLIENT_ID'
     - versionName: projects/${PROJECT_ID}/secrets/GOOGLE_OAUTH_CLIENT_SECRET/versions/latest
       env: 'GOOGLE_OAUTH_CLIENT_SECRET'
-    - versionName: projects/${PROJECT_ID}/secrets/GEMINI_MICROSOFT_AUTH_ID/versions/latest
-      env: 'GEMINI_MICROSOFT_AUTH_ID'
-    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_ID/versions/latest
-      env: 'MICROSOFT_OAUTH_CLIENT_ID'
-    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_SECRET/versions/latest
-      env: 'MICROSOFT_OAUTH_CLIENT_SECRET'
+    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_ID_TEST/versions/latest
+      env: 'MICROSOFT_OAUTH_CLIENT_ID_TEST'
+    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_SECRET_TEST/versions/latest
+      env: 'MICROSOFT_OAUTH_CLIENT_SECRET_TEST'
 
 
 # Ensure this Service Account has 'Storage Object Admin' on the state bucket

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
@@ -1,5 +1,25 @@
 substitutions:
   _REGION: "us-central1"
+  _AGENT_DISPLAY_NAME: "OSIRIS"
+  _MODEL_ARMOR_TEMPLATE_ID: "security-template"
+  _AGENT_SA: "adk-agent"
+  _BIGQUERY_URL: "https://bigquery-mcp-server-1057005221381.us-central1.run.app"
+  _DRIVE_URL: "https://drive-mcp-server-1057005221381.us-central1.run.app"
+  _GCS_URL: "https://gcs-mcp-server-1057005221381.us-central1.run.app"
+  _CALENDAR_URL: "https://calendar-mcp-server-1057005221381.us-central1.run.app"
+  _ONEDRIVE_URL: "https://onedrive-mcp-server-1057005221381.us-central1.run.app"
+  _ATLASSIAN_URL: "https://atlassian-mcp-server-1057005221381.us-central1.run.app"
+  _SHAREPOINT_URL: "https://sharepoint-mcp-server-1057005221381.us-central1.run.app"
+  _EKB_PIPELINE_URL: "https://ekb-pipeline-1057005221381.us-central1.run.app"
+  _METRICS_DATASET_ID: "agent_metrics"
+  _METRICS_TABLE_ID: "response_times"
+  _GE_APP_ID: "gemini-enterprise-17816266_1781626607357"
+  _GE_REGION: "global"
+  _GE_AGENT_DESCRIPTION: "OSIRIS - Organizational Search, Information Retrieval, and Intelligence System: A hierarchical multi-agent system designed to break information silos by searching across BigQuery, GCS, Google Drive, and Google Calendar, and managing EKB document ingestion."
+  _GOOGLE_OAUTH_SCOPES: "openid email https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/calendar.events.readonly https://www.googleapis.com/auth/meetings.space.readonly"
+  _MICROSOFT_OAUTH_SCOPES: "offline_access Files.Read.All Sites.Read.All"
+  _MICROSOFT_TENANT_ID: "93f8f3d2-54f6-417d-9a37-10ff2952f228"
+  
 
 steps:
   # Step 1: Initialize Terraform with Dynamic Backend
@@ -14,42 +34,163 @@ steps:
           -backend-config="prefix=terraform/state/ai-agent-resources"
     dir: 'terraform/ai_agent_resources'
 
-  # Step 2: Ensure code is formatted correctly
+  # Step 2: Run Terraform Apply
+  # Creates the required permissions and service accounts to run the agent
   - name: 'hashicorp/terraform:1.12.2'
-    id: 'tf-fmt'
-    args: ['fmt', '-check']
+    id: 'tf-apply'
+    args:
+      - 'apply'
+      - '-var=project_id=${PROJECT_ID}'
+      - '-var=main_region=${_REGION}'
+      - '-auto-approve'
     dir: 'terraform/ai_agent_resources'
-
-  # Step 3: Format Check & Tests (Python)
-  - name: 'python:3.12'
-    id: 'python-lint-and-tests'
-    entrypoint: 'sh'
+  
+  # Step 3: Unregister the agent from GE
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'ge-unregister-agent'
+    entrypoint: 'bash'
     args:
       - '-c'
       - |
-        apt-get update && apt-get install -y make
-        pip install uv
-        uv sync --group ai-agent --group dev
-        make run-agent-precommit
-        make test-agent
+        apt-get update && apt-get install -y jq curl
+        chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
+        
+        echo "Checking and deleting existing agent in GE..."
+        ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh delete-agent \
+          --project ${PROJECT_ID} \
+          --ge-location ${_GE_REGION} \
+          --app-id ${_GE_APP_ID} \
+          --agent-display-name "${_AGENT_DISPLAY_NAME}"
 
-  # Step 4: Validate the configuration syntax
-  - name: 'hashicorp/terraform:1.12.2'
-    id: 'tf-validate'
-    args: ['validate']
-    dir: 'terraform/ai_agent_resources'
-
-  # Step 4: Run Terraform Plan
-  - name: 'hashicorp/terraform:1.12.2'
-    id: 'tf-plan'
+  # Step 4: Delete all auth resources
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'ge-delete-auth-resources'
+    entrypoint: 'bash'
+    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
     args:
-      - 'plan'
-      - '-var=project_id=${PROJECT_ID}'
-      - '-var=main_region=${_REGION}'
-      - '-out=tfplan'
-    dir: 'terraform/ai_agent_resources'
+      - '-c'
+      - |
+        apt-get update && apt-get install -y jq curl
+        chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
 
-# This matches the custom SA you created in your bootstrap script
+        echo "Deleting GE Auth IDs $$GEMINI_GOOGLE_AUTH_ID and $$GEMINI_MICROSOFT_AUTH_ID..."
+        ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh delete-auth-ids \
+          --project ${PROJECT_ID} \
+          --ge-location ${_GE_REGION} \
+          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID,$$GEMINI_MICROSOFT_AUTH_ID"
+
+  # Step 5: Create new auth resources
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'ge-create-auth-resources'
+    entrypoint: 'bash'
+    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET', 'GEMINI_MICROSOFT_AUTH_ID', 'MICROSOFT_OAUTH_CLIENT_ID', 'MICROSOFT_OAUTH_CLIENT_SECRET']
+    args:
+      - '-c'
+      - |
+        apt-get update && apt-get install -y jq curl
+        chmod +x terraform/ai_agent_resources/scripts/ge_agent_manager.sh
+
+        echo "Creating GE Auth ID for Google: $$GEMINI_GOOGLE_AUTH_ID..."
+        ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh create-auth-ids \
+          --project ${PROJECT_ID} \
+          --ge-location ${_GE_REGION} \
+          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID" \
+          --client-id "$$GOOGLE_OAUTH_CLIENT_ID" \
+          --client-secret "$$GOOGLE_OAUTH_CLIENT_SECRET" \
+          --scopes "${_GOOGLE_OAUTH_SCOPES}" \
+          --auth-uri-base "https://accounts.google.com/o/oauth2/v2/auth" \
+          --token-uri "https://oauth2.googleapis.com/token" \
+          --auth-uri-extras "include_granted_scopes=true&access_type=offline"
+
+        echo "Creating GE Auth ID for Microsoft: $$GEMINI_MICROSOFT_AUTH_ID..."
+        ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh create-auth-ids \
+          --project ${PROJECT_ID} \
+          --ge-location ${_GE_REGION} \
+          --auth-ids "$$GEMINI_MICROSOFT_AUTH_ID" \
+          --client-id "$$MICROSOFT_OAUTH_CLIENT_ID" \
+          --client-secret "$$MICROSOFT_OAUTH_CLIENT_SECRET" \
+          --scopes "${_MICROSOFT_OAUTH_SCOPES}" \
+          --auth-uri-base "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/authorize" \
+          --token-uri "https://login.microsoftonline.com/${_MICROSOFT_TENANT_ID}/oauth2/v2.0/token" \
+          --prompt "select_account"
+
+  
+  # Step 6: Deploy the AI-Agent to Agent Engine
+  - name: 'python:3.12'
+    id: 'deploy-agent-engine'
+    entrypoint: 'sh'
+    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
+    args:
+      - '-c'
+      - |
+        pip install uv
+        uv export \
+          --group ai-agent \
+          --no-hashes \
+          --no-annotate \
+          -o agent/core_agent/requirements.txt
+        uv run --group ai-agent --group dev python -m agent.deployment.deploy \
+          --project ${PROJECT_ID} \
+          --location ${_REGION} \
+          --display-name "${_AGENT_DISPLAY_NAME}" \
+          --source-packages=./agent \
+          --entrypoint-module=agent.core_agent.agent \
+          --entrypoint-object=app \
+          --requirements-file=./agent/core_agent/requirements.txt \
+          --service-account=${_AGENT_SA}@${PROJECT_ID}.iam.gserviceaccount.com \
+          --min-instances=1 \
+          --memory=16Gi \
+          --num-workers=4 \
+          --set-env-vars="PROJECT_ID=${PROJECT_ID},REGION=${_REGION},LANDING_ZONE_BUCKET=${PROJECT_ID}-ai-agent-landing-zone,MODEL_ARMOR_TEMPLATE_ID=${_MODEL_ARMOR_TEMPLATE_ID},BIGQUERY_URL=${_BIGQUERY_URL},DRIVE_URL=${_DRIVE_URL},GCS_URL=${_GCS_URL},CALENDAR_URL=${_CALENDAR_URL},GEMINI_GOOGLE_AUTH_ID=$$GEMINI_GOOGLE_AUTH_ID,GEMINI_MICROSOFT_AUTH_ID=$$GEMINI_MICROSOFT_AUTH_ID,ONEDRIVE_URL=${_ONEDRIVE_URL},ATLASSIAN_URL=${_ATLASSIAN_URL},SHAREPOINT_URL=${_SHAREPOINT_URL},EKB_PIPELINE_URL=${_EKB_PIPELINE_URL},METRICS_PROJECT_ID=${PROJECT_ID},METRICS_DATASET_ID=${_METRICS_DATASET_ID},METRICS_TABLE_ID=${_METRICS_TABLE_ID}" 2>&1 | tee deploy_output.txt
+        
+        grep -o "reasoningEngines/[0-9]*" deploy_output.txt | tail -n 1 | cut -d'/' -f2 > /workspace/adk_resource.txt
+        echo "Captured ADK_RESOURCE_ID: $(cat /workspace/adk_resource.txt)"
+
+
+  # Step 7: Register the Agent in GE
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'ge-register-agent'
+    entrypoint: 'bash'
+    secretEnv: ['GEMINI_GOOGLE_AUTH_ID', 'GEMINI_MICROSOFT_AUTH_ID']
+    args:
+      - '-c'
+      - |
+        apt-get update && apt-get install -y jq curl
+        ADK_RESOURCE_ID=$(cat /workspace/adk_resource.txt)
+
+        if [ -z "$$ADK_RESOURCE_ID" ]; then
+            echo "Failed to capture ADK_RESOURCE_ID"
+            exit 1
+        fi
+
+        echo "Registering Agent in GE..."
+        ./terraform/ai_agent_resources/scripts/ge_agent_manager.sh register-agent \
+          --project ${PROJECT_ID} \
+          --ge-location ${_GE_REGION} \
+          --app-id ${_GE_APP_ID} \
+          --agent-display-name "${_AGENT_DISPLAY_NAME}" \
+          --agent-description "${_GE_AGENT_DESCRIPTION}" \
+          --agent-engine-location ${_REGION} \
+          --agent-engine-agent-id "$${ADK_RESOURCE_ID}" \
+          --auth-ids "$$GEMINI_GOOGLE_AUTH_ID,$$GEMINI_MICROSOFT_AUTH_ID"
+
+availableSecrets:
+  secretManager:
+    - versionName: projects/${PROJECT_ID}/secrets/GEMINI_GOOGLE_AUTH_ID/versions/latest
+      env: 'GEMINI_GOOGLE_AUTH_ID'
+    - versionName: projects/${PROJECT_ID}/secrets/GOOGLE_OAUTH_CLIENT_ID/versions/latest
+      env: 'GOOGLE_OAUTH_CLIENT_ID'
+    - versionName: projects/${PROJECT_ID}/secrets/GOOGLE_OAUTH_CLIENT_SECRET/versions/latest
+      env: 'GOOGLE_OAUTH_CLIENT_SECRET'
+    - versionName: projects/${PROJECT_ID}/secrets/GEMINI_MICROSOFT_AUTH_ID/versions/latest
+      env: 'GEMINI_MICROSOFT_AUTH_ID'
+    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_ID/versions/latest
+      env: 'MICROSOFT_OAUTH_CLIENT_ID'
+    - versionName: projects/${PROJECT_ID}/secrets/MICROSOFT_OAUTH_CLIENT_SECRET/versions/latest
+      env: 'MICROSOFT_OAUTH_CLIENT_SECRET'
+
+
+# Ensure this Service Account has 'Storage Object Admin' on the state bucket
 serviceAccount: 'projects/${PROJECT_ID}/serviceAccounts/${_SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com'
 
 # Configuration for the build runner

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
@@ -17,7 +17,7 @@ substitutions:
   _GE_REGION: "global"
   _GE_AGENT_DESCRIPTION: "OSIRIS - Organizational Search, Information Retrieval, and Intelligence System: A hierarchical multi-agent system designed to break information silos by searching across BigQuery, GCS, Google Drive, and Google Calendar, and managing EKB document ingestion."
   _GOOGLE_OAUTH_SCOPES: "openid email https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/bigquery https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/calendar.events.readonly https://www.googleapis.com/auth/meetings.space.readonly"
-  _MICROSOFT_OAUTH_SCOPES: "offline_access Files.Read.All Sites.Read.All"
+  _MICROSOFT_OAUTH_SCOPES: "offline_access Files.Read.All Sites.Read.All User.Read"
   _MICROSOFT_TENANT_ID: "93f8f3d2-54f6-417d-9a37-10ff2952f228"
   _GEMINI_GOOGLE_AUTH_ID: "google-workspace-authentication-test"
   _GEMINI_MICROSOFT_AUTH_ID: "microsoft-work-authentication-test"

--- a/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
+++ b/terraform/ai_agent_resources/ai-agent-services-cloud-build-ci.yaml
@@ -48,7 +48,7 @@ steps:
     args:
       - '-c'
       - |
-        apt-get update && apt-get install -y make
+        apt-get update && apt-get install -y make git
         pip install uv
         uv sync --group ai-agent --group dev
         make run-agent-precommit

--- a/terraform/ai_agent_resources/scripts/ge_agent_manager.sh
+++ b/terraform/ai_agent_resources/scripts/ge_agent_manager.sh
@@ -8,6 +8,7 @@ shift
 GE_LOCATION="global"
 GE_AGENT_DESCRIPTION="Agent capable of searching and retrieving information from Google Drive, GCP and GCS using user's credentials"
 ICON_URI="https://yt3.googleusercontent.com/lufyX7Ule20Ss0fpVdiFbRn8LfdUlKK2SpG2vHbRw2xQRlpG0egcgnepZvmD26wwdETKad4VcaA=s900-c-k-c0x00ffffff-no-rj"
+PROMPT_TYPE="consent"
 
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
@@ -27,6 +28,7 @@ while [[ "$#" -gt 0 ]]; do
         --agent-engine-location) AGENT_ENGINE_LOCATION="$2"; shift ;;
         --agent-description) GE_AGENT_DESCRIPTION="$2"; shift ;;
         --icon-uri) ICON_URI="$2"; shift ;;
+        --prompt) PROMPT_TYPE="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; exit 1 ;;
     esac
     shift
@@ -107,9 +109,7 @@ case "$COMMAND" in
         fi
         
         ENCODED_SCOPES="${OAUTH_SCOPES// /%20}"
-        
-        AUTH_URI="${AUTH_URI_BASE}?client_id=${CLIENT_ID}&redirect_uri=https%3A%2F%2Fvertexaisearch.cloud.google.com%2Fstatic%2Foauth%2Foauth.html&scope=${ENCODED_SCOPES}&response_type=code&prompt=consent"
-        
+        AUTH_URI="${AUTH_URI_BASE}?client_id=${CLIENT_ID}&redirect_uri=https%3A%2F%2Fvertexaisearch.cloud.google.com%2Fstatic%2Foauth%2Foauth.html&scope=${ENCODED_SCOPES}&response_type=code&prompt=${PROMPT_TYPE}"
         if [ -n "$AUTH_URI_EXTRAS" ]; then
             AUTH_URI="${AUTH_URI}&${AUTH_URI_EXTRAS}"
         fi


### PR DESCRIPTION
### Problem
Currently, when a standard (non-admin) user attempts to authorize the OneDrive or SharePoint connection via Gemini Enterprise, they encounter an "Admin approval needed" block from Microsoft Entra ID.

**Root cause:**
The script responsible for registering the OAuth connectors (`ge_agent_manager.sh`) was hardcoding the `prompt=consent` parameter in the authorization URI. This parameter explicitly forces Microsoft to request interactive user consent on every login. Since Entra ID corporate policies block standard users from granting permissions to sensitive scopes (such as `Files.Read.All`), the flow immediately fails, even if an administrator had already granted global tenant-wide Admin Consent.

### Solution
The solution is to avoid forcing the explicit consent request during Microsoft authorization, allowing Entra ID to assume the global consent previously granted by the administrator.

1. **Script Parameterization:** Modified the `ge_agent_manager.sh` file by adding an optional `--prompt` argument. If not provided, it maintains the original behavior (`consent`) to avoid affecting other functional connectors like Google Auth.
2. **Cloud Build Update:** Adjusted the continuous deployment pipeline (`ai-agent-services-cloud-build-cd.yaml`) to explicitly pass `--prompt "select_account"` exclusively during the creation of the Microsoft Auth ID.

By using `prompt=select_account`, the Microsoft platform simply prompts the user to select their account, silently verifies that the permissions have already been globally granted by the administrator, and issues the access tokens without displaying any blocking screens.

### Additional Notes
- Injecting this parameter into the local environment (ADK Pydantic configs) was discarded because the underlying library forces `prompt=consent` by default. Attempting to override it locally resulted in a duplicate parameter error from Microsoft (`AADSTS9000411`). The local environment retains its original behavior, which is manageable as it is typically used only by application administrators or developers.
