### PR TITLE
Add model armor permission to the SA

### DIFF
--- a/terraform/scripts/bootstrap.sh
+++ b/terraform/scripts/bootstrap.sh
@@ -93,6 +93,7 @@ ROLES=(
     "roles/cloudbuild.admin" # To manage (create and delete) Cloud Build triggers
     "roles/discoveryengine.admin" # To create Auth resources and register agents in Gemini Enterprise
     "roles/dlp.admin" # To manage DLP templates and jobs
+    "roles/modelarmor.admin" # To manage Model Armor templates
     "roles/bigquery.admin" # To manage BigQuery datasets and tables
     "roles/storage.admin" # To manage GCS buckets
     "roles/cloudtasks.admin" # To manage Cloud Tasks queues


### PR DESCRIPTION
Set modelarmor admin to the terraform SA to correctly create the template for Model Armor, previously this was created manually, but now is on Terraform