### PR TITLE
fix: resolve GE agent registration failure caused by empty project number in CD

### DIFF
--- a/terraform/ai_agent_resources/scripts/ge_agent_manager.sh
+++ b/terraform/ai_agent_resources/scripts/ge_agent_manager.sh
@@ -155,12 +155,11 @@ case "$COMMAND" in
             exit 1
         fi
         
-        PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)")
         AGENTS_URL="${BASE_URL}/collections/default_collection/engines/${APP_ID}/assistants/default_assistant/agents"
         
         REASONING_ENGINE_PATH="projects/${PROJECT_ID}/locations/${AGENT_ENGINE_LOCATION}/reasoningEngines/${AGENT_ENGINE_AGENT_ID}"
         
-        AUTH_ARRAY_JSON=$(echo "$AUTH_IDS" | jq -R -c 'split(",") | map(select(length > 0) | "projects/'"${PROJECT_NUMBER}"'/locations/'"${GE_LOCATION}"'/authorizations/" + .)')
+        AUTH_ARRAY_JSON=$(echo "$AUTH_IDS" | jq -R -c 'split(",") | map(select(length > 0) | "projects/'"${PROJECT_ID}"'/locations/'"${GE_LOCATION}"'/authorizations/" + .)')
         
         echo "Registering Agent ${AGENT_DISPLAY_NAME} in GE..."
         


### PR DESCRIPTION
#### 🐞 The Error
The CD pipeline was consistently failing during the **Registering Agent in GE** step when deploying from Cloud Build (specifically observed in Europe regions). 
The pipeline failed with the following API error:
```json
{
  "error": {
    "code": 400,
    "message": "Failed to allocate quota for agent creation.",
    "status": "FAILED_PRECONDITION"
  }
}
```
Additionally, a warning was observed in the logs just before the crash:
`Regional Access Boundary HTTP request failed after retries...`

#### 🔍 The Root Cause
1. The `Regional Access Boundary` warning was being thrown by the `gcloud projects describe` command executing inside the Cloud Build environment.
2. Because of this failure, the `PROJECT_NUMBER` variable was left empty.
3. The empty variable corrupted the JSON payload (`AUTH_ARRAY_JSON`) sent to the Discovery Engine API, creating malformed paths like `"projects//locations/eu/authorizations/..."` (notice the double slash).
4. The Discovery Engine API rejected the corrupted resource path with a generic `FAILED_PRECONDITION` (quota) error.

#### 🛠️ The Solution
- **Removed** the fragile `gcloud projects describe` command entirely from `ge_agent_manager.sh`.
- **Replaced** the usage of `PROJECT_NUMBER` with `PROJECT_ID` when constructing the authorizations JSON array. The Discovery Engine API natively accepts the Project ID in resource paths.
- This bypasses the Regional Access Boundary networking issues in Cloud Build and guarantees the JSON payload is always correctly formatted.
